### PR TITLE
Externalize babel helpers via @babel/plugin-transform-runtime

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,5 +6,16 @@
         "modules": false
       }
     ]
+  ],
+  "plugins": [
+    [
+      "@babel/plugin-transform-runtime",
+      {
+        "corejs": false,
+        "helpers": true,
+        "regenerator": false,
+        "useESModules": false
+      }
+    ]
   ]
 }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "devDependencies": {
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",
+    "@babel/plugin-transform-runtime": "^7.3.4",
     "@types/react": "^15.0.21",
     "babel-loader": "^8.0.0",
     "babel-preset-airbnb": "^3.2.0",
@@ -74,6 +75,7 @@
     "scrollspy"
   ],
   "dependencies": {
+    "@babel/runtime": "^7.3.4",
     "consolidated-events": "^1.1.0 || ^2.0.0",
     "prop-types": "^15.0.0",
     "react-is": "^16.6.3"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -15,6 +15,8 @@ export default [
     plugins: [
       babel({
         exclude: ['node_modules/**'],
+        runtimeHelpers: true,
+        externalHelpers: true,
       }),
     ],
   },


### PR DESCRIPTION
Babel 7 now allows you to use the runtime transform for external helpers
that are built as modules in @babel/runtime package, without having to
drag in core-js and regenerator runtime. This means that our code will
remain mostly the same as it is today with the exception of the Babel
helpers being pulled from discrete modules instead of being inlined into
this package. That means smaller bundle sizes.

Although @babel/runtime does not show up in the code we check in, it is
a dependency as a result of this transform so I've added it there.

Here's the diff of the es build with this change (the cjs diff is
similar with the main difference being require statements are used
instead of import statements):

```diff
0a1,5
> import _classCallCheck from '@babel/runtime/helpers/classCallCheck';
> import _createClass from '@babel/runtime/helpers/createClass';
> import _possibleConstructorReturn from '@babel/runtime/helpers/possibleConstructorReturn';
> import _getPrototypeOf from '@babel/runtime/helpers/getPrototypeOf';
> import _inherits from '@babel/runtime/helpers/inherits';
6,74d10
< function _classCallCheck(instance, Constructor) {
<   if (!(instance instanceof Constructor)) {
<     throw new TypeError("Cannot call a class as a function");
<   }
< }
<
< function _defineProperties(target, props) {
<   for (var i = 0; i < props.length; i++) {
<     var descriptor = props[i];
<     descriptor.enumerable = descriptor.enumerable || false;
<     descriptor.configurable = true;
<     if ("value" in descriptor) descriptor.writable = true;
<     Object.defineProperty(target, descriptor.key, descriptor);
<   }
< }
<
< function _createClass(Constructor, protoProps, staticProps) {
<   if (protoProps) _defineProperties(Constructor.prototype, protoProps);
<   if (staticProps) _defineProperties(Constructor, staticProps);
<   return Constructor;
< }
<
< function _inherits(subClass, superClass) {
<   if (typeof superClass !== "function" && superClass !== null) {
<     throw new TypeError("Super expression must either be null or a function");
<   }
<
<   subClass.prototype = Object.create(superClass && superClass.prototype, {
<     constructor: {
<       value: subClass,
<       writable: true,
<       configurable: true
<     }
<   });
<   if (superClass) _setPrototypeOf(subClass, superClass);
< }
<
< function _getPrototypeOf(o) {
<   _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) {
<     return o.__proto__ || Object.getPrototypeOf(o);
<   };
<   return _getPrototypeOf(o);
< }
<
< function _setPrototypeOf(o, p) {
<   _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) {
<     o.__proto__ = p;
<     return o;
<   };
<
<   return _setPrototypeOf(o, p);
< }
<
< function _assertThisInitialized(self) {
<   if (self === void 0) {
<     throw new ReferenceError("this hasn't been initialised - super() hasn't been called");
<   }
<
<   return self;
< }
<
< function _possibleConstructorReturn(self, call) {
<   if (call && (typeof call === "object" || typeof call === "function")) {
<     return call;
<   }
<
<   return _assertThisInitialized(self);
< }
<
```