### PR TITLE
Add onProgress to track the scroll progress between enter / leave

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,16 @@ below) has changed.
 />
 ```
 
+If you need more information over the scrolling progress you can use pass a function to the `onProgress` prop.
+```js
+<Waypoint
+  onProgress={this._handleProgress}
+/>
+```
+It will fire on every position change inside the object. The information is passed
+with the `progress` attribute that ranges from 0 - 1. Using this can result in a big performance hit,
+as a lot of scrolling events are firing, only use this with caution.
+
 Waypoints can take a child, allowing you to track when a section of content
 enters or leaves the viewport. For details, see [Children](#children), below.
 
@@ -104,6 +114,12 @@ enters or leaves the viewport. For details, see [Children](#children), below.
      * Function called when waypoint leaves viewport
      */
     onLeave: PropTypes.func,
+
+    /**
+     * Function called when waypoint is in the viewport and the scroll position changed
+     */
+    onProgress: PropTypes.func,
+
 
     /**
      * Function called when waypoint position changes
@@ -165,7 +181,7 @@ enters or leaves the viewport. For details, see [Children](#children), below.
   },
 ```
 
-All callbacks (`onEnter`/`onLeave`/`onPositionChange`) receive an object as the
+All callbacks (`onEnter`/`onLeave`/`onProgress`/`onPositionChange`) receive an object as the
 only argument. That object has the following properties:
 
 - `currentPosition` - the position that the waypoint has at the moment. One

--- a/index.d.ts
+++ b/index.d.ts
@@ -43,6 +43,13 @@ declare namespace Waypoint {
         viewportBottom: number;
     }
 
+    interface CallbackProgressArgs extends CallbackArgs {
+        /*
+         * Indicates the progress between the enter and leave event with a number between 0 and 1.
+         */
+        progress: number;
+    }
+
     interface WaypointProps {
         /**
          * Function called when waypoint enters viewport
@@ -55,6 +62,12 @@ declare namespace Waypoint {
          * @param {CallbackArgs} args
          */
         onLeave?: (args: CallbackArgs) => void;
+
+        /**
+         * Function called when waypoint is inside viewport and a scroll event happens.
+         * @param {CallbackProgressArgs} args
+         */
+        onProgress?: (args: CallbackProgressArgs) => void;
 
         /**
          * Function called when waypoint position changes

--- a/src/getCurrentProgress.js
+++ b/src/getCurrentProgress.js
@@ -1,0 +1,23 @@
+function clamp(val, min, max) {
+  return Math.min(Math.max(val, min), max);
+}
+
+/**
+ * @param {object} bounds An object with bounds data for the waypoint and
+ *   scrollable parent
+ * @return {integer} The current scroll progress of the Waypoint inside of its
+ *  scrollable parent
+ */
+export default function getCurrentProgress({
+  viewportBottom,
+  viewportTop,
+  waypointBottom,
+  waypointTop,
+}) {
+  const viewportHeight = viewportBottom - viewportTop || 1;
+  const waypointHeight = waypointBottom - waypointTop || 1;
+  const distance = viewportHeight + waypointHeight;
+  const traveled = waypointBottom - viewportTop;
+  const progress = 1 - clamp(traveled / distance, 0, 1);
+  return progress;
+}


### PR DESCRIPTION
Hey all,

this PR adds a really useful feature to react-waypoint. An `onProgress` handler.
This is useful when one wants to animate something regarding the scroll position, imagine for example a progress indicator how far you've read the page or similar.

I did not write the logic here myself, but used https://github.com/davidkofahl/react-waypoint-with-progress/commits/master as base and fixed it up a bit so a PR could be made.

I created a test page here: https://waypoints-on-progress.netlify.com/, the code for it can be found in this branch: https://github.com/TN1ck/react-waypoint-with-progress/tree/progress-test-page

I added some docs, typescript definitions and more.
There should be no performance hit, the only thing that was added on every scroll are some simple math calculations.

If there is something I can add to improve this PR, please tell me!