### PR TITLE
Fix wrapped refs being called on every render

### DIFF
--- a/src/waypoint.jsx
+++ b/src/waypoint.jsx
@@ -36,6 +36,15 @@ export class Waypoint extends React.PureComponent {
 
     this.refElement = (e) => {
       this._ref = e;
+
+      const { children } = this.props;
+      if (children && children.ref && (isDOMElement(children) || isForwardRef(children))) {
+        if (typeof children.ref === 'function') {
+          children.ref(e);
+        } else {
+          children.ref.current = e;
+        }
+      }
     };
   }
 
@@ -302,18 +311,7 @@ export class Waypoint extends React.PureComponent {
     }
 
     if (isDOMElement(children) || isForwardRef(children)) {
-      const ref = (node) => {
-        this.refElement(node);
-        if (children.ref) {
-          if (typeof children.ref === 'function') {
-            children.ref(node);
-          } else {
-            children.ref.current = node;
-          }
-        }
-      };
-
-      return React.cloneElement(children, { ref });
+      return React.cloneElement(children, { ref: this.refElement });
     }
 
     return React.cloneElement(children, { innerRef: this.refElement });


### PR DESCRIPTION
I noticed that if I do something like this:

```javascript
setRef = el => {
  if (el) {
    console.log('mounting', el)
  } else {
    console.log('unmounting')
  }
}

render() {
  const { onEnterViewport, onLeaveViewport } = this.props
  <Waypoint onEnter={onEnterViewport} onLeave={onLeaveViewport}>
    <div ref={this.setRef} />
  </Waypoint>
}
```

I see `unmounting` followed by `mounting` in the console every time my component renders. This is happening because the wrapper ref added in #278 changes on every render, so React calls it again (per [Caveats with callback refs](https://reactjs.org/docs/refs-and-the-dom.html#caveats-with-callback-refs)). This is a problem for me because I’m constructing and destroying a stateful video player in my `setRef()`.

To fix this, I have:

* added unit tests that verify the original behaviour;
* added unit tests that fail in this case;
* moved the ref-wrapping logic into the existing refElement instance method;
* now the failing unit tests pass.