### PR TITLE
Add support for scrollable ancestor with overflow: overlay

### DIFF
--- a/src/waypoint.jsx
+++ b/src/waypoint.jsx
@@ -157,7 +157,7 @@ export class Waypoint extends React.PureComponent {
         : style.getPropertyValue('overflow-y');
       const overflow = overflowDirec || style.getPropertyValue('overflow');
 
-      if (overflow === 'auto' || overflow === 'scroll') {
+      if (overflow === 'auto' || overflow === 'scroll' || overflow === 'overlay') {
         return node;
       }
     }


### PR DESCRIPTION
Scrollable ancestors can also have `overflow: overlay;`. Currently, react-waypoint does not support that case. This PR adds that support.