### PR TITLE
Disable TravisCI's npm cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ sudo: false
 node_js:
   - node
   - lts/*
+cache:
+  npm: false
 env:
   - REACT_VERSION=15.3
   - REACT_VERSION=16.0


### PR DESCRIPTION
It seems to conflicts with the diferent npm versions used in the matrix.

This is because of my change in #322 that always tests on the lasted stable Node.js version and the release of Node.js 7 that bundles npm 7. I think it's good these gets covered in testing but the cache seems to be a problem.