### PR TITLE
Support React 17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,6 @@ cache:
 env:
   - REACT_VERSION=15.3
   - REACT_VERSION=16.0
+  - REACT_VERSION=17.0
 before_script:
   - npm install react-dom@^$REACT_VERSION react@^$REACT_VERSION

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "author": "Brigade Engineering",
   "license": "MIT",
   "peerDependencies": {
-    "react": "^15.3.0 || ^16.0.0"
+    "react": "^15.3.0 || ^16.0.0 || ^17.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",
@@ -76,7 +76,7 @@
   "dependencies": {
     "consolidated-events": "^1.1.0 || ^2.0.0",
     "prop-types": "^15.0.0",
-    "react-is": "^16.6.3"
+    "react-is": "^17.0.1"
   },
   "browserify": {
     "transform": [


### PR DESCRIPTION
This PR adds testing for React 17 and relaxes the peer dependency constraint on `react` to not warn for React 17

It also updates `react-is` to version 17