### PR TITLE
Upgrade babel-preset-airbnb to version 5

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,13 +1,22 @@
 {
   "env": {
     "test": {
-      "presets": [["airbnb", { "modules": true }]]
+      "presets": [["airbnb", {
+        "modules": true,
+        "transformRuntime": false
+      }]]
     },
     "production": {
-      "presets": [["airbnb", { "modules": false }]]
+      "presets": [["airbnb", {
+        "modules": false,
+        "transformRuntime": false
+      }]]
     },
     "development": {
-      "presets": [["airbnb", { "modules": false }]]
+      "presets": [["airbnb", {
+        "modules": false,
+        "transformRuntime": false
+      }]]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@rollup/plugin-babel": "^5.2.1",
     "@types/react": "^15.0.21",
     "babel-loader": "^8.0.0",
-    "babel-preset-airbnb": "^3.2.0",
+    "babel-preset-airbnb": "^5.0.0",
     "eslint": "^7.12.0",
     "eslint-config-airbnb": "^18.2.0",
     "eslint-plugin-import": "^2.22.0",


### PR DESCRIPTION
This comes with new browser targets:

> Chrome 35 -> 40, Edge 14 -> 18, IE 9 -> 11, Firefox 52 -> 72, Safari 8 -> 12, Android 30 -> 35

It doesn't change the generated code in practice but if some new JS feature gets used that happened to be supported by all of these new targets, they won't get transpiled anymore.