### PR TITLE
Upgrade test related dependencies & adapt tests

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -27,12 +27,18 @@ module.exports = (config) => {
     },
 
     webpack: {
+      mode: 'development',
       module: {
-        loaders: [
+        rules: [
           {
             test: /\.jsx?$/,
-            loaders: ['babel-loader?cacheDirectory=true'],
             exclude: /node_modules/,
+            use: {
+              loader: 'babel-loader',
+              options: {
+                cacheDirectory: true,
+              },
+            },
           },
         ],
       },

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",
     "@rollup/plugin-babel": "^5.2.1",
-    "@types/react": "^15.0.21",
+    "@types/react": "^16.14.5",
     "babel-loader": "^8.0.0",
     "babel-preset-airbnb": "^5.0.0",
     "eslint": "^7.12.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "in-publish": "^2.0.0",
     "jasmine-core": "2.6.4",
     "jest": "^26.6.3",
-    "karma": "^5.2.3",
+    "karma": "^6.0.2",
     "karma-chrome-launcher": "^3.1.0",
     "karma-cli": "^2.0.0",
     "karma-firefox-launcher": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "karma-cli": "^2.0.0",
     "karma-firefox-launcher": "^2.1.0",
     "karma-jasmine": "^1.1.2",
-    "karma-webpack": "^3.0.5",
+    "karma-webpack": "^4.0.2",
     "loose-envify": "^1.4.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
@@ -67,7 +67,8 @@
     "rimraf": "^3.0.2",
     "rollup": "^2.33.2",
     "safe-publish-latest": "^1.1.1",
-    "webpack": "^2.3.3"
+    "webpack": "^4.46.0",
+    "webpack-cli": "^4.4.0"
   },
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "eslint-plugin-jsx-a11y": "^6.3.1",
     "eslint-plugin-react": "^7.21.2",
     "in-publish": "^2.0.0",
-    "jasmine-core": "2.6.4",
+    "jasmine-core": "^2.99.1",
     "jest": "^26.6.3",
     "karma": "^6.0.2",
     "karma-chrome-launcher": "^3.1.0",

--- a/test/browser/waypoint_test.jsx
+++ b/test/browser/waypoint_test.jsx
@@ -27,35 +27,43 @@ function scrollNodeTo(node, scrollTop) {
 }
 
 describe('<Waypoint>', () => {
+  let props;
+  let margin;
+  let parentHeight;
+  let parentStyle;
+  let topSpacerHeight;
+  let bottomSpacerHeight;
+  let subject;
+
   beforeEach(() => {
     jasmine.clock().install();
     spyOn(console, 'log');
-    this.props = {
+    props = {
       onEnter: jasmine.createSpy('onEnter'),
       onLeave: jasmine.createSpy('onLeave'),
       onPositionChange: jasmine.createSpy('onPositionChange'),
     };
 
-    this.margin = 10;
-    this.parentHeight = 100;
+    margin = 10;
+    parentHeight = 100;
 
-    this.parentStyle = {
-      height: this.parentHeight,
+    parentStyle = {
+      height: parentHeight,
       overflow: 'auto',
       position: 'relative',
       width: 100,
-      margin: this.margin, // Normalize the space above the viewport.
+      margin, // Normalize the space above the viewport.
     };
 
-    this.topSpacerHeight = 0;
-    this.bottomSpacerHeight = 0;
+    topSpacerHeight = 0;
+    bottomSpacerHeight = 0;
 
-    this.subject = () => {
+    subject = () => {
       const el = renderAttached(
-        <div style={this.parentStyle}>
-          <div style={{ height: this.topSpacerHeight }} />
-          <Waypoint {...this.props} />
-          <div style={{ height: this.bottomSpacerHeight }} />
+        <div style={parentStyle}>
+          <div style={{ height: topSpacerHeight }} />
+          <Waypoint {...props} />
+          <div style={{ height: bottomSpacerHeight }} />
         </div>,
       );
 
@@ -73,17 +81,16 @@ describe('<Waypoint>', () => {
   });
 
   it('logs to the console when called with debug = true', () => {
-    this.props.debug = true;
-    this.subject();
+    props.debug = true;
+    subject();
     expect(console.log).toHaveBeenCalled(); // eslint-disable-line no-console
   });
 
   describe('when the Waypoint is visible on mount', () => {
     beforeEach(() => {
-      this.topSpacerHeight = 90;
-      this.bottomSpacerHeight = 200;
-      this.parentComponent = this.subject();
-      this.scrollable = this.parentComponent;
+      topSpacerHeight = 90;
+      bottomSpacerHeight = 200;
+      subject();
     });
 
     it('does not log to the console', () => {
@@ -92,458 +99,468 @@ describe('<Waypoint>', () => {
     });
 
     it('calls the onEnter handler', () => {
-      expect(this.props.onEnter).toHaveBeenCalledWith({
+      expect(props.onEnter).toHaveBeenCalledWith({
         currentPosition: Waypoint.inside,
         previousPosition: undefined,
         event: null,
-        waypointTop: this.margin + this.topSpacerHeight,
-        waypointBottom: this.margin + this.topSpacerHeight,
-        viewportTop: this.margin,
-        viewportBottom: this.margin + this.parentHeight,
+        waypointTop: margin + topSpacerHeight,
+        waypointBottom: margin + topSpacerHeight,
+        viewportTop: margin,
+        viewportBottom: margin + parentHeight,
       });
     });
 
     it('calls the onPositionChange handler', () => {
-      expect(this.props.onPositionChange)
+      expect(props.onPositionChange)
         .toHaveBeenCalledWith({
           currentPosition: Waypoint.inside,
           previousPosition: undefined,
           event: null,
-          waypointTop: this.margin + this.topSpacerHeight,
-          waypointBottom: this.margin + this.topSpacerHeight,
-          viewportTop: this.margin,
-          viewportBottom: this.margin + this.parentHeight,
+          waypointTop: margin + topSpacerHeight,
+          waypointBottom: margin + topSpacerHeight,
+          viewportTop: margin,
+          viewportBottom: margin + parentHeight,
         });
     });
 
     it('does not call the onLeave handler', () => {
-      expect(this.props.onLeave).not.toHaveBeenCalled();
+      expect(props.onLeave).not.toHaveBeenCalled();
     });
   });
 
   describe('when the Waypoint is visible on mount and has topOffset < -100%', () => {
     beforeEach(() => {
-      this.props.topOffset = '-200%';
+      props.topOffset = '-200%';
 
-      this.topSpacerHeight = 90;
-      this.bottomSpacerHeight = 200;
-      this.parentComponent = this.subject();
-      this.scrollable = this.parentComponent;
+      topSpacerHeight = 90;
+      bottomSpacerHeight = 200;
+      subject();
     });
 
     it('calls the onEnter handler', () => {
-      expect(this.props.onEnter).toHaveBeenCalledWith({
+      expect(props.onEnter).toHaveBeenCalledWith({
         currentPosition: Waypoint.inside,
         previousPosition: undefined,
         event: null,
-        waypointTop: this.margin + this.topSpacerHeight,
-        waypointBottom: this.margin + this.topSpacerHeight,
-        viewportTop: this.margin - (this.parentHeight * 2),
-        viewportBottom: this.margin + this.parentHeight,
+        waypointTop: margin + topSpacerHeight,
+        waypointBottom: margin + topSpacerHeight,
+        viewportTop: margin - (parentHeight * 2),
+        viewportBottom: margin + parentHeight,
       });
     });
 
     it('calls the onPositionChange handler', () => {
-      expect(this.props.onPositionChange)
+      expect(props.onPositionChange)
         .toHaveBeenCalledWith({
           currentPosition: Waypoint.inside,
           previousPosition: undefined,
           event: null,
-          waypointTop: this.margin + this.topSpacerHeight,
-          waypointBottom: this.margin + this.topSpacerHeight,
-          viewportTop: this.margin - (this.parentHeight * 2),
-          viewportBottom: this.margin + this.parentHeight,
+          waypointTop: margin + topSpacerHeight,
+          waypointBottom: margin + topSpacerHeight,
+          viewportTop: margin - (parentHeight * 2),
+          viewportBottom: margin + parentHeight,
         });
     });
 
     it('does not call the onLeave handler', () => {
-      expect(this.props.onLeave).not.toHaveBeenCalled();
+      expect(props.onLeave).not.toHaveBeenCalled();
     });
   });
 
   describe('when the Waypoint is visible on mount and has bottomOffset < -100%', () => {
     beforeEach(() => {
-      this.props.bottomOffset = '-200%';
+      props.bottomOffset = '-200%';
 
-      this.topSpacerHeight = 90;
-      this.bottomSpacerHeight = 200;
-      this.parentComponent = this.subject();
-      this.scrollable = this.parentComponent;
+      topSpacerHeight = 90;
+      bottomSpacerHeight = 200;
+      subject();
     });
 
     it('calls the onEnter handler', () => {
-      expect(this.props.onEnter).toHaveBeenCalledWith({
+      expect(props.onEnter).toHaveBeenCalledWith({
         currentPosition: Waypoint.inside,
         previousPosition: undefined,
         event: null,
-        waypointTop: this.margin + this.topSpacerHeight,
-        waypointBottom: this.margin + this.topSpacerHeight,
-        viewportTop: this.margin,
-        viewportBottom: this.margin + (this.parentHeight * 3),
+        waypointTop: margin + topSpacerHeight,
+        waypointBottom: margin + topSpacerHeight,
+        viewportTop: margin,
+        viewportBottom: margin + (parentHeight * 3),
       });
     });
 
     it('calls the onPositionChange handler', () => {
-      expect(this.props.onPositionChange)
+      expect(props.onPositionChange)
         .toHaveBeenCalledWith({
           currentPosition: Waypoint.inside,
           previousPosition: undefined,
           event: null,
-          waypointTop: this.margin + this.topSpacerHeight,
-          waypointBottom: this.margin + this.topSpacerHeight,
-          viewportTop: this.margin,
-          viewportBottom: this.margin + (this.parentHeight * 3),
+          waypointTop: margin + topSpacerHeight,
+          waypointBottom: margin + topSpacerHeight,
+          viewportTop: margin,
+          viewportBottom: margin + (parentHeight * 3),
         });
     });
 
     it('does not call the onLeave handler', () => {
-      expect(this.props.onLeave).not.toHaveBeenCalled();
+      expect(props.onLeave).not.toHaveBeenCalled();
     });
   });
 
   describe('when the Waypoint is visible on mount and offsets < -100%', () => {
     beforeEach(() => {
-      this.props.topOffset = '-200%';
-      this.props.bottomOffset = '-200%';
+      props.topOffset = '-200%';
+      props.bottomOffset = '-200%';
 
-      this.topSpacerHeight = 90;
-      this.bottomSpacerHeight = 200;
-      this.parentComponent = this.subject();
-      this.scrollable = this.parentComponent;
+      topSpacerHeight = 90;
+      bottomSpacerHeight = 200;
+      subject();
     });
 
     it('calls the onEnter handler', () => {
-      expect(this.props.onEnter).toHaveBeenCalledWith({
+      expect(props.onEnter).toHaveBeenCalledWith({
         currentPosition: Waypoint.inside,
         previousPosition: undefined,
         event: null,
-        waypointTop: this.margin + this.topSpacerHeight,
-        waypointBottom: this.margin + this.topSpacerHeight,
-        viewportTop: this.margin - (this.parentHeight * 2),
-        viewportBottom: this.margin + (this.parentHeight * 3),
+        waypointTop: margin + topSpacerHeight,
+        waypointBottom: margin + topSpacerHeight,
+        viewportTop: margin - (parentHeight * 2),
+        viewportBottom: margin + (parentHeight * 3),
       });
     });
 
     it('calls the onPositionChange handler', () => {
-      expect(this.props.onPositionChange)
+      expect(props.onPositionChange)
         .toHaveBeenCalledWith({
           currentPosition: Waypoint.inside,
           previousPosition: undefined,
           event: null,
-          waypointTop: this.margin + this.topSpacerHeight,
-          waypointBottom: this.margin + this.topSpacerHeight,
-          viewportTop: this.margin - (this.parentHeight * 2),
-          viewportBottom: this.margin + (this.parentHeight * 3),
+          waypointTop: margin + topSpacerHeight,
+          waypointBottom: margin + topSpacerHeight,
+          viewportTop: margin - (parentHeight * 2),
+          viewportBottom: margin + (parentHeight * 3),
         });
     });
 
     it('does not call the onLeave handler', () => {
-      expect(this.props.onLeave).not.toHaveBeenCalled();
+      expect(props.onLeave).not.toHaveBeenCalled();
     });
   });
 
   describe('when scrolling while the waypoint is visible', () => {
+    let parentComponent;
+    let scrollable;
+
     beforeEach(() => {
-      this.topSpacerHeight = 90;
-      this.bottomSpacerHeight = 200;
-      this.parentComponent = this.subject();
-      this.scrollable = this.parentComponent;
-      scrollNodeTo(this.scrollable, this.topSpacerHeight / 2);
+      topSpacerHeight = 90;
+      bottomSpacerHeight = 200;
+      parentComponent = subject();
+      scrollable = parentComponent;
+      scrollNodeTo(scrollable, topSpacerHeight / 2);
     });
 
     it('does not call the onEnter handler again', () => {
-      expect(this.props.onEnter.calls.count()).toBe(1);
+      expect(props.onEnter.calls.count()).toBe(1);
     });
 
     it('does not call the onLeave handler', () => {
-      expect(this.props.onLeave).not.toHaveBeenCalled();
+      expect(props.onLeave).not.toHaveBeenCalled();
     });
 
     it('does not call the onPositionChange handler again', () => {
-      expect(this.props.onPositionChange.calls.count()).toBe(1);
+      expect(props.onPositionChange.calls.count()).toBe(1);
     });
   });
 
   describe('when scrolling past the waypoint while it is visible', () => {
+    let parentComponent;
+    let scrollable;
+
     beforeEach(() => {
-      this.topSpacerHeight = 90;
-      this.bottomSpacerHeight = 200;
-      this.parentComponent = this.subject();
-      this.scrollable = this.parentComponent;
-      scrollNodeTo(this.scrollable, this.topSpacerHeight + 10);
+      topSpacerHeight = 90;
+      bottomSpacerHeight = 200;
+      parentComponent = subject();
+      scrollable = parentComponent;
+      scrollNodeTo(scrollable, topSpacerHeight + 10);
     });
 
     it('the onLeave handler is called', () => {
-      expect(this.props.onLeave)
+      expect(props.onLeave)
         .toHaveBeenCalledWith({
           currentPosition: Waypoint.above,
           previousPosition: Waypoint.inside,
           event: jasmine.any(Event),
-          waypointTop: this.margin - 10,
-          waypointBottom: this.margin - 10,
-          viewportTop: this.margin,
-          viewportBottom: this.margin + this.parentHeight,
+          waypointTop: margin - 10,
+          waypointBottom: margin - 10,
+          viewportTop: margin,
+          viewportBottom: margin + parentHeight,
         });
     });
 
     it('does not call the onEnter handler', () => {
-      expect(this.props.onEnter.calls.count()).toBe(1);
+      expect(props.onEnter.calls.count()).toBe(1);
     });
 
     it('the onPositionChange is called', () => {
-      expect(this.props.onPositionChange)
+      expect(props.onPositionChange)
         .toHaveBeenCalledWith({
           currentPosition: Waypoint.above,
           previousPosition: Waypoint.inside,
           event: jasmine.any(Event),
-          waypointTop: this.margin - 10,
-          waypointBottom: this.margin - 10,
-          viewportTop: this.margin,
-          viewportBottom: this.margin + this.parentHeight,
+          waypointTop: margin - 10,
+          waypointBottom: margin - 10,
+          viewportTop: margin,
+          viewportBottom: margin + parentHeight,
         });
     });
   });
 
   describe('when the Waypoint is below the bottom', () => {
     beforeEach(() => {
-      this.topSpacerHeight = 200;
+      topSpacerHeight = 200;
 
       // The bottom spacer needs to be tall enough to force the Waypoint to exit
       // the viewport when scrolled all the way down.
-      this.bottomSpacerHeight = 3000;
+      bottomSpacerHeight = 3000;
     });
 
     it('does not call the onEnter handler on mount', () => {
-      this.subject();
-      expect(this.props.onEnter).not.toHaveBeenCalled();
+      subject();
+      expect(props.onEnter).not.toHaveBeenCalled();
     });
 
     it('does not call the onLeave handler on mount', () => {
-      this.subject();
-      expect(this.props.onLeave).not.toHaveBeenCalled();
+      subject();
+      expect(props.onLeave).not.toHaveBeenCalled();
     });
 
     it('calls the onPositionChange handler', () => {
-      this.subject();
-      expect(this.props.onPositionChange)
+      subject();
+      expect(props.onPositionChange)
         .toHaveBeenCalledWith({
           currentPosition: Waypoint.below,
           previousPosition: undefined,
           event: null,
-          waypointTop: this.margin + this.topSpacerHeight,
-          waypointBottom: this.margin + this.topSpacerHeight,
-          viewportTop: this.margin,
-          viewportBottom: this.margin + this.parentHeight,
+          waypointTop: margin + topSpacerHeight,
+          waypointBottom: margin + topSpacerHeight,
+          viewportTop: margin,
+          viewportBottom: margin + parentHeight,
         });
     });
 
     describe('with children', () => {
+      let childrenHeight;
+
       beforeEach(() => {
-        this.childrenHeight = 80;
-        this.props.children = (
+        childrenHeight = 80;
+        props.children = (
           <div>
-            <div style={{ height: this.childrenHeight / 2 }} />
-            <div style={{ height: this.childrenHeight / 2 }} />
+            <div style={{ height: childrenHeight / 2 }} />
+            <div style={{ height: childrenHeight / 2 }} />
           </div>
         );
       });
 
       it('calls the onEnter handler when scrolling down far enough', () => {
-        this.component = this.subject();
-        this.props.onPositionChange.calls.reset();
-        scrollNodeTo(this.component, 100);
+        const component = subject();
+        props.onPositionChange.calls.reset();
+        scrollNodeTo(component, 100);
 
-        expect(this.props.onEnter)
+        expect(props.onEnter)
           .toHaveBeenCalledWith({
             currentPosition: Waypoint.inside,
             previousPosition: Waypoint.below,
             event: jasmine.any(Event),
-            waypointTop: this.margin + this.topSpacerHeight - 100,
-            waypointBottom: this.margin + this.topSpacerHeight - 100 + this.childrenHeight,
-            viewportTop: this.margin,
-            viewportBottom: this.margin + this.parentHeight,
+            waypointTop: margin + topSpacerHeight - 100,
+            waypointBottom: margin + topSpacerHeight - 100 + childrenHeight,
+            viewportTop: margin,
+            viewportBottom: margin + parentHeight,
           });
       });
     });
 
     describe('when scrolling down just below the threshold', () => {
+      let component;
+
       beforeEach(() => {
-        this.component = this.subject();
-        this.props.onPositionChange.calls.reset();
-        scrollNodeTo(this.component, 99);
+        component = subject();
+        props.onPositionChange.calls.reset();
+        scrollNodeTo(component, 99);
       });
 
       it('does not call the onEnter handler', () => {
-        expect(this.props.onEnter).not.toHaveBeenCalled();
+        expect(props.onEnter).not.toHaveBeenCalled();
       });
 
       it('does not call the onLeave handler', () => {
-        expect(this.props.onLeave).not.toHaveBeenCalled();
+        expect(props.onLeave).not.toHaveBeenCalled();
       });
 
       it('does not call the onPositionChange handler', () => {
-        expect(this.props.onPositionChange).not.toHaveBeenCalled();
+        expect(props.onPositionChange).not.toHaveBeenCalled();
       });
     });
 
     it('calls the onEnter handler when scrolling down past the threshold', () => {
-      scrollNodeTo(this.subject(), 100);
+      scrollNodeTo(subject(), 100);
 
-      expect(this.props.onEnter)
+      expect(props.onEnter)
         .toHaveBeenCalledWith({
           currentPosition: Waypoint.inside,
           previousPosition: Waypoint.below,
           event: jasmine.any(Event),
-          waypointTop: this.margin + this.topSpacerHeight - 100,
-          waypointBottom: this.margin + this.topSpacerHeight - 100,
-          viewportTop: this.margin,
-          viewportBottom: this.margin + this.parentHeight,
+          waypointTop: margin + topSpacerHeight - 100,
+          waypointBottom: margin + topSpacerHeight - 100,
+          viewportTop: margin,
+          viewportBottom: margin + parentHeight,
         });
     });
 
     it('calls the onPositionChange handler when scrolling down past the threshold', () => {
-      scrollNodeTo(this.subject(), 100);
+      scrollNodeTo(subject(), 100);
 
-      expect(this.props.onPositionChange)
+      expect(props.onPositionChange)
         .toHaveBeenCalledWith({
           currentPosition: Waypoint.inside,
           previousPosition: Waypoint.below,
           event: jasmine.any(Event),
-          waypointTop: this.margin + this.topSpacerHeight - 100,
-          waypointBottom: this.margin + this.topSpacerHeight - 100,
-          viewportTop: this.margin,
-          viewportBottom: this.margin + this.parentHeight,
+          waypointTop: margin + topSpacerHeight - 100,
+          waypointBottom: margin + topSpacerHeight - 100,
+          viewportTop: margin,
+          viewportBottom: margin + parentHeight,
         });
     });
 
     it('does not call the onLeave handler when scrolling down past the threshold', () => {
-      scrollNodeTo(this.subject(), 100);
-      expect(this.props.onLeave).not.toHaveBeenCalled();
+      scrollNodeTo(subject(), 100);
+      expect(props.onLeave).not.toHaveBeenCalled();
     });
 
     describe('when `fireOnRapidScroll` is disabled', () => {
       beforeEach(() => {
-        this.props.fireOnRapidScroll = false;
+        props.fireOnRapidScroll = false;
       });
 
       it('calls the onEnter handler when scrolling down past the threshold', () => {
-        scrollNodeTo(this.subject(), 100);
+        scrollNodeTo(subject(), 100);
 
-        expect(this.props.onEnter)
+        expect(props.onEnter)
           .toHaveBeenCalledWith({
             currentPosition: Waypoint.inside,
             previousPosition: Waypoint.below,
             event: jasmine.any(Event),
-            waypointTop: this.margin + this.topSpacerHeight - 100,
-            waypointBottom: this.margin + this.topSpacerHeight - 100,
-            viewportTop: this.margin,
-            viewportBottom: this.margin + this.parentHeight,
+            waypointTop: margin + topSpacerHeight - 100,
+            waypointBottom: margin + topSpacerHeight - 100,
+            viewportTop: margin,
+            viewportBottom: margin + parentHeight,
           });
       });
 
       it('calls the onPositionChange handler when scrolling down past the threshold', () => {
-        scrollNodeTo(this.subject(), 100);
+        scrollNodeTo(subject(), 100);
 
-        expect(this.props.onPositionChange)
+        expect(props.onPositionChange)
           .toHaveBeenCalledWith({
             currentPosition: Waypoint.inside,
             previousPosition: Waypoint.below,
             event: jasmine.any(Event),
-            waypointTop: this.margin + this.topSpacerHeight - 100,
-            waypointBottom: this.margin + this.topSpacerHeight - 100,
-            viewportTop: this.margin,
-            viewportBottom: this.margin + this.parentHeight,
+            waypointTop: margin + topSpacerHeight - 100,
+            waypointBottom: margin + topSpacerHeight - 100,
+            viewportTop: margin,
+            viewportBottom: margin + parentHeight,
           });
       });
 
       it('does not call the onLeave handler when scrolling down past the threshold', () => {
-        scrollNodeTo(this.subject(), 100);
+        scrollNodeTo(subject(), 100);
 
-        expect(this.props.onLeave).not.toHaveBeenCalled();
+        expect(props.onLeave).not.toHaveBeenCalled();
       });
     });
 
     describe('when scrolling quickly past the waypoint', () => {
+      let scrollQuicklyPast;
+      let component;
+
       // If you scroll really fast, we might not get a scroll event when the
       // waypoint is in view. We will get a scroll event before going into view
       // though, and one after. We want to treat this as if the waypoint was
       // visible for a brief moment, and so we fire both onEnter and onLeave.
       beforeEach(() => {
-        this.scrollQuicklyPast = () => {
-          this.component = this.subject();
-          this.props.onPositionChange.calls.reset();
-          scrollNodeTo(this.component, this.topSpacerHeight + this.bottomSpacerHeight);
+        scrollQuicklyPast = () => {
+          component = subject();
+          props.onPositionChange.calls.reset();
+          scrollNodeTo(component, topSpacerHeight + bottomSpacerHeight);
         };
       });
 
       it('calls the onEnter handler', () => {
-        this.scrollQuicklyPast();
-        expect(this.props.onEnter)
+        scrollQuicklyPast();
+        expect(props.onEnter)
           .toHaveBeenCalledWith({
             currentPosition: Waypoint.inside,
             previousPosition: Waypoint.below,
             event: jasmine.any(Event),
-            waypointTop: this.margin - this.bottomSpacerHeight + this.parentHeight,
-            waypointBottom: this.margin - this.bottomSpacerHeight + this.parentHeight,
-            viewportTop: this.margin,
-            viewportBottom: this.margin + this.parentHeight,
+            waypointTop: margin - bottomSpacerHeight + parentHeight,
+            waypointBottom: margin - bottomSpacerHeight + parentHeight,
+            viewportTop: margin,
+            viewportBottom: margin + parentHeight,
           });
       });
 
       it('calls the onLeave handler', () => {
-        this.scrollQuicklyPast();
-        expect(this.props.onLeave)
+        scrollQuicklyPast();
+        expect(props.onLeave)
           .toHaveBeenCalledWith({
             currentPosition: Waypoint.above,
             previousPosition: Waypoint.inside,
             event: jasmine.any(Event),
-            waypointTop: this.margin - this.bottomSpacerHeight + this.parentHeight,
-            waypointBottom: this.margin - this.bottomSpacerHeight + this.parentHeight,
-            viewportTop: this.margin,
-            viewportBottom: this.margin + this.parentHeight,
+            waypointTop: margin - bottomSpacerHeight + parentHeight,
+            waypointBottom: margin - bottomSpacerHeight + parentHeight,
+            viewportTop: margin,
+            viewportBottom: margin + parentHeight,
           });
       });
 
       it('calls the onPositionChange handler', () => {
-        this.scrollQuicklyPast();
-        expect(this.props.onPositionChange)
+        scrollQuicklyPast();
+        expect(props.onPositionChange)
           .toHaveBeenCalledWith({
             currentPosition: Waypoint.above,
             previousPosition: Waypoint.below,
             event: jasmine.any(Event),
-            waypointTop: this.margin - this.bottomSpacerHeight + this.parentHeight,
-            waypointBottom: this.margin - this.bottomSpacerHeight + this.parentHeight,
-            viewportTop: this.margin,
-            viewportBottom: this.margin + this.parentHeight,
+            waypointTop: margin - bottomSpacerHeight + parentHeight,
+            waypointBottom: margin - bottomSpacerHeight + parentHeight,
+            viewportTop: margin,
+            viewportBottom: margin + parentHeight,
           });
       });
 
       describe('when `fireOnRapidScroll` is disabled', () => {
         beforeEach(() => {
-          this.props.fireOnRapidScroll = false;
+          props.fireOnRapidScroll = false;
         });
 
         it('does not call the onEnter handler', () => {
-          this.scrollQuicklyPast();
-          expect(this.props.onEnter).not.toHaveBeenCalled();
+          scrollQuicklyPast();
+          expect(props.onEnter).not.toHaveBeenCalled();
         });
 
         it('does not call the onLeave handler', () => {
-          this.scrollQuicklyPast();
-          expect(this.props.onLeave).not.toHaveBeenCalled();
+          scrollQuicklyPast();
+          expect(props.onLeave).not.toHaveBeenCalled();
         });
 
         it('calls the onPositionChange handler', () => {
-          this.scrollQuicklyPast();
-          expect(this.props.onPositionChange)
+          scrollQuicklyPast();
+          expect(props.onPositionChange)
             .toHaveBeenCalledWith({
               currentPosition: Waypoint.above,
               previousPosition: Waypoint.below,
               event: jasmine.any(Event),
-              waypointTop: this.margin - this.bottomSpacerHeight + this.parentHeight,
-              waypointBottom: this.margin - this.bottomSpacerHeight + this.parentHeight,
-              viewportTop: this.margin,
-              viewportBottom: this.margin + this.parentHeight,
+              waypointTop: margin - bottomSpacerHeight + parentHeight,
+              waypointBottom: margin - bottomSpacerHeight + parentHeight,
+              viewportTop: margin,
+              viewportBottom: margin + parentHeight,
             });
         });
       });
@@ -552,23 +569,23 @@ describe('<Waypoint>', () => {
     describe('with a non-zero topOffset', () => {
       describe('and the topOffset is passed as a percentage', () => {
         beforeEach(() => {
-          this.props.topOffset = '-10%';
+          props.topOffset = '-10%';
         });
 
         it('calls the onLeave handler when scrolling down past the bottom offset', () => {
-          this.component = this.subject();
-          this.props.onPositionChange.calls.reset();
-          scrollNodeTo(this.component, 211);
+          const component = subject();
+          props.onPositionChange.calls.reset();
+          scrollNodeTo(component, 211);
 
-          expect(this.props.onLeave)
+          expect(props.onLeave)
             .toHaveBeenCalledWith({
               currentPosition: Waypoint.above,
               previousPosition: Waypoint.inside,
               event: jasmine.any(Event),
-              waypointTop: this.margin + this.topSpacerHeight - 211,
-              waypointBottom: this.margin + this.topSpacerHeight - 211,
-              viewportTop: this.margin + this.parentHeight * -0.1,
-              viewportBottom: this.margin + this.parentHeight,
+              waypointTop: margin + topSpacerHeight - 211,
+              waypointBottom: margin + topSpacerHeight - 211,
+              viewportTop: margin + parentHeight * -0.1,
+              viewportBottom: margin + parentHeight,
             });
         });
       });
@@ -577,288 +594,288 @@ describe('<Waypoint>', () => {
     describe('with a non-zero bottomOffset', () => {
       describe('and the bottomOffset is passed as a percentage', () => {
         beforeEach(() => {
-          this.props.bottomOffset = '-10%';
+          props.bottomOffset = '-10%';
         });
 
         it('does not call the onEnter handler when scrolling down near the bottom offset', () => {
-          this.component = this.subject();
-          this.props.onPositionChange.calls.reset();
-          scrollNodeTo(this.component, 89);
+          const component = subject();
+          props.onPositionChange.calls.reset();
+          scrollNodeTo(component, 89);
 
-          expect(this.props.onEnter).not.toHaveBeenCalled();
+          expect(props.onEnter).not.toHaveBeenCalled();
         });
 
         it('does not call the onLeave handler when scrolling down near the bottom offset', () => {
-          this.component = this.subject();
-          this.props.onPositionChange.calls.reset();
-          scrollNodeTo(this.component, 89);
+          const component = subject();
+          props.onPositionChange.calls.reset();
+          scrollNodeTo(component, 89);
 
-          expect(this.props.onLeave).not.toHaveBeenCalled();
+          expect(props.onLeave).not.toHaveBeenCalled();
         });
 
         it('does not call onPositionChange handler when scrolling down near bottom offset', () => {
-          this.component = this.subject();
-          this.props.onPositionChange.calls.reset();
-          scrollNodeTo(this.component, 89);
+          const component = subject();
+          props.onPositionChange.calls.reset();
+          scrollNodeTo(component, 89);
 
-          expect(this.props.onPositionChange).not.toHaveBeenCalled();
+          expect(props.onPositionChange).not.toHaveBeenCalled();
         });
 
         it('calls the onEnter handler when scrolling down past the bottom offset', () => {
-          this.component = this.subject();
-          this.props.onPositionChange.calls.reset();
-          scrollNodeTo(this.component, 90);
+          const component = subject();
+          props.onPositionChange.calls.reset();
+          scrollNodeTo(component, 90);
 
-          expect(this.props.onEnter)
+          expect(props.onEnter)
             .toHaveBeenCalledWith({
               currentPosition: Waypoint.inside,
               previousPosition: Waypoint.below,
               event: jasmine.any(Event),
-              waypointTop: this.margin + this.topSpacerHeight - 90,
-              waypointBottom: this.margin + this.topSpacerHeight - 90,
-              viewportTop: this.margin,
-              viewportBottom: this.margin + Math.floor(this.parentHeight * 1.1),
+              waypointTop: margin + topSpacerHeight - 90,
+              waypointBottom: margin + topSpacerHeight - 90,
+              viewportTop: margin,
+              viewportBottom: margin + Math.floor(parentHeight * 1.1),
             });
         });
 
         it('does not call the onLeave handler when scrolling down past the bottom offset', () => {
-          this.component = this.subject();
-          this.props.onPositionChange.calls.reset();
-          scrollNodeTo(this.component, 90);
+          const component = subject();
+          props.onPositionChange.calls.reset();
+          scrollNodeTo(component, 90);
 
-          expect(this.props.onLeave).not.toHaveBeenCalled();
+          expect(props.onLeave).not.toHaveBeenCalled();
         });
 
         it('calls the onPositionChange handler when scrolling down past the bottom offset', () => {
-          this.component = this.subject();
-          this.props.onPositionChange.calls.reset();
-          scrollNodeTo(this.component, 90);
+          const component = subject();
+          props.onPositionChange.calls.reset();
+          scrollNodeTo(component, 90);
 
-          expect(this.props.onPositionChange)
+          expect(props.onPositionChange)
             .toHaveBeenCalledWith({
               currentPosition: Waypoint.inside,
               previousPosition: Waypoint.below,
               event: jasmine.any(Event),
-              waypointTop: this.margin + this.topSpacerHeight - 90,
-              waypointBottom: this.margin + this.topSpacerHeight - 90,
-              viewportTop: this.margin,
-              viewportBottom: this.margin + Math.floor(this.parentHeight * 1.1),
+              waypointTop: margin + topSpacerHeight - 90,
+              waypointBottom: margin + topSpacerHeight - 90,
+              viewportTop: margin,
+              viewportBottom: margin + Math.floor(parentHeight * 1.1),
             });
         });
       });
 
       describe('and the bottom offset is passed as a numeric string', () => {
         beforeEach(() => {
-          this.props.bottomOffset = '-10';
+          props.bottomOffset = '-10';
         });
 
         it('does not call the onEnter handler when scrolling down near the bottom offset', () => {
-          this.component = this.subject();
-          this.props.onPositionChange.calls.reset();
-          scrollNodeTo(this.component, 89);
+          const component = subject();
+          props.onPositionChange.calls.reset();
+          scrollNodeTo(component, 89);
 
-          expect(this.props.onEnter).not.toHaveBeenCalled();
+          expect(props.onEnter).not.toHaveBeenCalled();
         });
 
         it('does not call the onLeave handler when scrolling down near the bottom offset', () => {
-          this.component = this.subject();
-          this.props.onPositionChange.calls.reset();
-          scrollNodeTo(this.component, 89);
+          const component = subject();
+          props.onPositionChange.calls.reset();
+          scrollNodeTo(component, 89);
 
-          expect(this.props.onLeave).not.toHaveBeenCalled();
+          expect(props.onLeave).not.toHaveBeenCalled();
         });
 
         it('does not call onPositionChange handler when scrolling down near bottom offset', () => {
-          this.component = this.subject();
-          this.props.onPositionChange.calls.reset();
-          scrollNodeTo(this.component, 89);
+          const component = subject();
+          props.onPositionChange.calls.reset();
+          scrollNodeTo(component, 89);
 
-          expect(this.props.onPositionChange).not.toHaveBeenCalled();
+          expect(props.onPositionChange).not.toHaveBeenCalled();
         });
 
         it('calls the onEnter handler when scrolling down past the bottom offset', () => {
-          this.component = this.subject();
-          this.props.onPositionChange.calls.reset();
-          scrollNodeTo(this.component, 90);
+          const component = subject();
+          props.onPositionChange.calls.reset();
+          scrollNodeTo(component, 90);
 
-          expect(this.props.onEnter)
+          expect(props.onEnter)
             .toHaveBeenCalledWith({
               currentPosition: Waypoint.inside,
               previousPosition: Waypoint.below,
               event: jasmine.any(Event),
-              waypointTop: this.margin + this.topSpacerHeight - 90,
-              waypointBottom: this.margin + this.topSpacerHeight - 90,
-              viewportTop: this.margin,
-              viewportBottom: this.margin + this.parentHeight + 10,
+              waypointTop: margin + topSpacerHeight - 90,
+              waypointBottom: margin + topSpacerHeight - 90,
+              viewportTop: margin,
+              viewportBottom: margin + parentHeight + 10,
             });
         });
 
         it('does not call the onLeave handler when scrolling down past the bottom offset', () => {
-          this.component = this.subject();
-          this.props.onPositionChange.calls.reset();
-          scrollNodeTo(this.component, 90);
+          const component = subject();
+          props.onPositionChange.calls.reset();
+          scrollNodeTo(component, 90);
 
-          expect(this.props.onLeave).not.toHaveBeenCalled();
+          expect(props.onLeave).not.toHaveBeenCalled();
         });
 
         it('calls the onPositionChange handler when scrolling down past the bottom offset', () => {
-          this.component = this.subject();
-          this.props.onPositionChange.calls.reset();
-          scrollNodeTo(this.component, 90);
+          const component = subject();
+          props.onPositionChange.calls.reset();
+          scrollNodeTo(component, 90);
 
-          expect(this.props.onPositionChange)
+          expect(props.onPositionChange)
             .toHaveBeenCalledWith({
               currentPosition: Waypoint.inside,
               previousPosition: Waypoint.below,
               event: jasmine.any(Event),
-              waypointTop: this.margin + this.topSpacerHeight - 90,
-              waypointBottom: this.margin + this.topSpacerHeight - 90,
-              viewportTop: this.margin,
-              viewportBottom: this.margin + this.parentHeight + 10,
+              waypointTop: margin + topSpacerHeight - 90,
+              waypointBottom: margin + topSpacerHeight - 90,
+              viewportTop: margin,
+              viewportBottom: margin + parentHeight + 10,
             });
         });
       });
 
       describe('and the bottom offset is passed as a pixel string', () => {
         beforeEach(() => {
-          this.props.bottomOffset = '-10px';
+          props.bottomOffset = '-10px';
         });
 
         it('does not call the onEnter handler when scrolling down near the bottom offset', () => {
-          this.component = this.subject();
-          this.props.onPositionChange.calls.reset();
-          scrollNodeTo(this.component, 89);
+          const component = subject();
+          props.onPositionChange.calls.reset();
+          scrollNodeTo(component, 89);
 
-          expect(this.props.onEnter).not.toHaveBeenCalled();
+          expect(props.onEnter).not.toHaveBeenCalled();
         });
 
         it('does not call the onLeave handler when scrolling down near the bottom offset', () => {
-          this.component = this.subject();
-          this.props.onPositionChange.calls.reset();
-          scrollNodeTo(this.component, 89);
+          const component = subject();
+          props.onPositionChange.calls.reset();
+          scrollNodeTo(component, 89);
 
-          expect(this.props.onLeave).not.toHaveBeenCalled();
+          expect(props.onLeave).not.toHaveBeenCalled();
         });
 
         it('does not call onPositionChange handler when scrolling down near bottom offset', () => {
-          this.component = this.subject();
-          this.props.onPositionChange.calls.reset();
-          scrollNodeTo(this.component, 89);
+          const component = subject();
+          props.onPositionChange.calls.reset();
+          scrollNodeTo(component, 89);
 
-          expect(this.props.onPositionChange).not.toHaveBeenCalled();
+          expect(props.onPositionChange).not.toHaveBeenCalled();
         });
 
         it('calls the onEnter handler when scrolling down past the bottom offset', () => {
-          this.component = this.subject();
-          this.props.onPositionChange.calls.reset();
-          scrollNodeTo(this.component, 90);
+          const component = subject();
+          props.onPositionChange.calls.reset();
+          scrollNodeTo(component, 90);
 
-          expect(this.props.onEnter)
+          expect(props.onEnter)
             .toHaveBeenCalledWith({
               currentPosition: Waypoint.inside,
               previousPosition: Waypoint.below,
               event: jasmine.any(Event),
-              waypointTop: this.margin + this.topSpacerHeight - 90,
-              waypointBottom: this.margin + this.topSpacerHeight - 90,
-              viewportTop: this.margin,
-              viewportBottom: this.margin + this.parentHeight + 10,
+              waypointTop: margin + topSpacerHeight - 90,
+              waypointBottom: margin + topSpacerHeight - 90,
+              viewportTop: margin,
+              viewportBottom: margin + parentHeight + 10,
             });
         });
 
         it('does not call the onLeave handler when scrolling down past the bottom offset', () => {
-          this.component = this.subject();
-          this.props.onPositionChange.calls.reset();
-          scrollNodeTo(this.component, 90);
+          const component = subject();
+          props.onPositionChange.calls.reset();
+          scrollNodeTo(component, 90);
 
-          expect(this.props.onLeave).not.toHaveBeenCalled();
+          expect(props.onLeave).not.toHaveBeenCalled();
         });
 
         it('calls the onPositionChange handler when scrolling down past the bottom offset', () => {
-          this.component = this.subject();
-          this.props.onPositionChange.calls.reset();
-          scrollNodeTo(this.component, 90);
+          const component = subject();
+          props.onPositionChange.calls.reset();
+          scrollNodeTo(component, 90);
 
-          expect(this.props.onPositionChange)
+          expect(props.onPositionChange)
             .toHaveBeenCalledWith({
               currentPosition: Waypoint.inside,
               previousPosition: Waypoint.below,
               event: jasmine.any(Event),
-              waypointTop: this.margin + this.topSpacerHeight - 90,
-              waypointBottom: this.margin + this.topSpacerHeight - 90,
-              viewportTop: this.margin,
-              viewportBottom: this.margin + this.parentHeight + 10,
+              waypointTop: margin + topSpacerHeight - 90,
+              waypointBottom: margin + topSpacerHeight - 90,
+              viewportTop: margin,
+              viewportBottom: margin + parentHeight + 10,
             });
         });
       });
 
       describe('and the bottom offset is passed as a number', () => {
         beforeEach(() => {
-          this.props.bottomOffset = -10;
+          props.bottomOffset = -10;
         });
 
         it('does not call the onEnter handler when scrolling down near the bottom offset', () => {
-          this.component = this.subject();
-          this.props.onPositionChange.calls.reset();
-          scrollNodeTo(this.component, 89);
+          const component = subject();
+          props.onPositionChange.calls.reset();
+          scrollNodeTo(component, 89);
 
-          expect(this.props.onEnter).not.toHaveBeenCalled();
+          expect(props.onEnter).not.toHaveBeenCalled();
         });
 
         it('does not call the onLeave handler when scrolling down near the bottom offset', () => {
-          this.component = this.subject();
-          this.props.onPositionChange.calls.reset();
-          scrollNodeTo(this.component, 89);
+          const component = subject();
+          props.onPositionChange.calls.reset();
+          scrollNodeTo(component, 89);
 
-          expect(this.props.onLeave).not.toHaveBeenCalled();
+          expect(props.onLeave).not.toHaveBeenCalled();
         });
 
         it('does not call onPositionChange handler when scrolling down near bottom offset', () => {
-          this.component = this.subject();
-          this.props.onPositionChange.calls.reset();
-          scrollNodeTo(this.component, 89);
+          const component = subject();
+          props.onPositionChange.calls.reset();
+          scrollNodeTo(component, 89);
 
-          expect(this.props.onPositionChange).not.toHaveBeenCalled();
+          expect(props.onPositionChange).not.toHaveBeenCalled();
         });
 
         it('calls the onEnter handler when scrolling down past the bottom offset', () => {
-          this.component = this.subject();
-          this.props.onPositionChange.calls.reset();
-          scrollNodeTo(this.component, 90);
+          const component = subject();
+          props.onPositionChange.calls.reset();
+          scrollNodeTo(component, 90);
 
-          expect(this.props.onEnter)
+          expect(props.onEnter)
             .toHaveBeenCalledWith({
               currentPosition: Waypoint.inside,
               previousPosition: Waypoint.below,
               event: jasmine.any(Event),
-              waypointTop: this.margin + this.topSpacerHeight - 90,
-              waypointBottom: this.margin + this.topSpacerHeight - 90,
-              viewportTop: this.margin,
-              viewportBottom: this.margin + this.parentHeight + 10,
+              waypointTop: margin + topSpacerHeight - 90,
+              waypointBottom: margin + topSpacerHeight - 90,
+              viewportTop: margin,
+              viewportBottom: margin + parentHeight + 10,
             });
         });
 
         it('does not call the onLeave handler when scrolling down past the bottom offset', () => {
-          this.component = this.subject();
-          this.props.onPositionChange.calls.reset();
-          scrollNodeTo(this.component, 90);
+          const component = subject();
+          props.onPositionChange.calls.reset();
+          scrollNodeTo(component, 90);
 
-          expect(this.props.onLeave).not.toHaveBeenCalled();
+          expect(props.onLeave).not.toHaveBeenCalled();
         });
 
         it('calls onPositionChange handler when scrolling down past bottom offset', () => {
-          this.component = this.subject();
-          this.props.onPositionChange.calls.reset();
-          scrollNodeTo(this.component, 90);
+          const component = subject();
+          props.onPositionChange.calls.reset();
+          scrollNodeTo(component, 90);
 
-          expect(this.props.onPositionChange)
+          expect(props.onPositionChange)
             .toHaveBeenCalledWith({
               currentPosition: Waypoint.inside,
               previousPosition: Waypoint.below,
               event: jasmine.any(Event),
-              waypointTop: this.margin + this.topSpacerHeight - 90,
-              waypointBottom: this.margin + this.topSpacerHeight - 90,
-              viewportTop: this.margin,
-              viewportBottom: this.margin + this.parentHeight + 10,
+              waypointTop: margin + topSpacerHeight - 90,
+              waypointBottom: margin + topSpacerHeight - 90,
+              viewportTop: margin,
+              viewportBottom: margin + parentHeight + 10,
             });
         });
       });
@@ -867,8 +884,8 @@ describe('<Waypoint>', () => {
 
   describe('when the Waypoint has children', () => {
     it('does not throw with a DOM Element as a child', () => {
-      this.props.children = <div />;
-      expect(this.subject).not.toThrow();
+      props.children = <div />;
+      expect(subject).not.toThrow();
     });
 
     it('does not throw with a Stateful Component as a child', () => {
@@ -879,8 +896,8 @@ describe('<Waypoint>', () => {
         }
       }
 
-      this.props.children = <StatefulComponent />;
-      expect(this.subject).not.toThrow();
+      props.children = <StatefulComponent />;
+      expect(subject).not.toThrow();
     });
 
     it('errors when a Stateful Component does not provide ref to Waypoint', () => {
@@ -891,186 +908,191 @@ describe('<Waypoint>', () => {
         }
       }
 
-      this.props.children = <StatefulComponent />;
-      expect(this.subject).toThrowError(refNotUsedErrorMessage);
+      props.children = <StatefulComponent />;
+      expect(subject).toThrowError(refNotUsedErrorMessage);
     });
 
     it('does not throw with a Stateless Component as a child', () => {
       const StatelessComponent = ({ innerRef }) => <div ref={innerRef} />;
 
-      this.props.children = <StatelessComponent />;
-      expect(this.subject).not.toThrow();
+      props.children = <StatelessComponent />;
+      expect(subject).not.toThrow();
     });
 
     it('errors when a Stateless Component does not provide ref to Waypoint', () => {
       const StatelessComponent = () => <div />;
 
-      this.props.children = <StatelessComponent />;
-      expect(this.subject).toThrowError(refNotUsedErrorMessage);
+      props.children = <StatelessComponent />;
+      expect(subject).toThrowError(refNotUsedErrorMessage);
     });
   });
 
   describe('when the Waypoint has children and is above the top', () => {
+    let childrenHeight;
+    let scrollable;
+
     beforeEach(() => {
-      this.topSpacerHeight = 200;
-      this.bottomSpacerHeight = 200;
-      this.childrenHeight = 100;
-      this.props.children = <div style={{ height: this.childrenHeight }} />;
-      this.scrollable = this.subject();
+      topSpacerHeight = 200;
+      bottomSpacerHeight = 200;
+      childrenHeight = 100;
+      props.children = <div style={{ height: childrenHeight }} />;
+      scrollable = subject();
 
       // Because of how we detect when a Waypoint is scrolled past without any
       // scroll event fired when it was visible, we need to reset callback
       // spies.
-      scrollNodeTo(this.scrollable, 400);
-      this.props.onEnter.calls.reset();
-      this.props.onLeave.calls.reset();
-      scrollNodeTo(this.scrollable, 400);
+      scrollNodeTo(scrollable, 400);
+      props.onEnter.calls.reset();
+      props.onLeave.calls.reset();
+      scrollNodeTo(scrollable, 400);
     });
 
     it('does not call the onEnter handler', () => {
-      expect(this.props.onEnter).not.toHaveBeenCalled();
+      expect(props.onEnter).not.toHaveBeenCalled();
     });
 
     it('does not call the onLeave handler', () => {
-      expect(this.props.onLeave).not.toHaveBeenCalled();
+      expect(props.onLeave).not.toHaveBeenCalled();
     });
 
     it('calls the onEnter handler when scrolled back up just past the bottom', () => {
-      scrollNodeTo(this.scrollable, this.topSpacerHeight + 50);
+      scrollNodeTo(scrollable, topSpacerHeight + 50);
 
-      expect(this.props.onEnter)
+      expect(props.onEnter)
         .toHaveBeenCalledWith({
           currentPosition: Waypoint.inside,
           previousPosition: Waypoint.above,
           event: jasmine.any(Event),
           waypointTop: -40,
-          waypointBottom: -40 + this.childrenHeight,
-          viewportTop: this.margin,
-          viewportBottom: this.margin + this.parentHeight,
+          waypointBottom: -40 + childrenHeight,
+          viewportTop: margin,
+          viewportBottom: margin + parentHeight,
         });
     });
 
     it('does not call the onLeave handler when scrolled back up just past the bottom', () => {
-      scrollNodeTo(this.scrollable, this.topSpacerHeight + 50);
+      scrollNodeTo(scrollable, topSpacerHeight + 50);
 
-      expect(this.props.onLeave).not.toHaveBeenCalled();
+      expect(props.onLeave).not.toHaveBeenCalled();
     });
   });
 
   describe('when the Waypoint is above the top', () => {
+    let scrollable;
+
     beforeEach(() => {
-      this.topSpacerHeight = 200;
-      this.bottomSpacerHeight = 200;
-      this.scrollable = this.subject();
+      topSpacerHeight = 200;
+      bottomSpacerHeight = 200;
+      scrollable = subject();
 
       // Because of how we detect when a Waypoint is scrolled past without any
       // scroll event fired when it was visible, we need to reset callback
       // spies.
-      scrollNodeTo(this.scrollable, 400);
-      this.props.onEnter.calls.reset();
-      this.props.onLeave.calls.reset();
-      this.props.onPositionChange.calls.reset();
-      scrollNodeTo(this.scrollable, 400);
+      scrollNodeTo(scrollable, 400);
+      props.onEnter.calls.reset();
+      props.onLeave.calls.reset();
+      props.onPositionChange.calls.reset();
+      scrollNodeTo(scrollable, 400);
     });
 
     it('does not call the onEnter handler', () => {
-      expect(this.props.onEnter).not.toHaveBeenCalled();
+      expect(props.onEnter).not.toHaveBeenCalled();
     });
 
     it('does not call the onLeave handler', () => {
-      expect(this.props.onLeave).not.toHaveBeenCalled();
+      expect(props.onLeave).not.toHaveBeenCalled();
     });
 
     it('does not call the onPositionChange handler', () => {
-      expect(this.props.onPositionChange).not.toHaveBeenCalled();
+      expect(props.onPositionChange).not.toHaveBeenCalled();
     });
 
     it('does not call the onEnter handler when scrolling up not past the threshold', () => {
-      scrollNodeTo(this.scrollable, 201);
+      scrollNodeTo(scrollable, 201);
 
-      expect(this.props.onEnter).not.toHaveBeenCalled();
+      expect(props.onEnter).not.toHaveBeenCalled();
     });
 
     it('does not call the onLeave handler when scrolling up not past the threshold', () => {
-      scrollNodeTo(this.scrollable, 201);
+      scrollNodeTo(scrollable, 201);
 
-      expect(this.props.onLeave).not.toHaveBeenCalled();
+      expect(props.onLeave).not.toHaveBeenCalled();
     });
 
     it('does not call onPositionChange handler when scrolling up not past the threshold', () => {
-      scrollNodeTo(this.scrollable, 201);
+      scrollNodeTo(scrollable, 201);
 
-      expect(this.props.onPositionChange).not.toHaveBeenCalled();
+      expect(props.onPositionChange).not.toHaveBeenCalled();
     });
 
     describe('when scrolling up past the threshold', () => {
       beforeEach(() => {
-        scrollNodeTo(this.scrollable, 200);
+        scrollNodeTo(scrollable, 200);
       });
 
       it('calls the onEnter handler', () => {
-        expect(this.props.onEnter)
+        expect(props.onEnter)
           .toHaveBeenCalledWith({
             currentPosition: Waypoint.inside,
             previousPosition: Waypoint.above,
             event: jasmine.any(Event),
-            waypointTop: this.margin + this.topSpacerHeight - 200,
-            waypointBottom: this.margin + this.topSpacerHeight - 200,
-            viewportTop: this.margin,
-            viewportBottom: this.margin + this.parentHeight,
+            waypointTop: margin + topSpacerHeight - 200,
+            waypointBottom: margin + topSpacerHeight - 200,
+            viewportTop: margin,
+            viewportBottom: margin + parentHeight,
           });
       });
 
       it('does not call the onLeave handler', () => {
-        expect(this.props.onLeave).not.toHaveBeenCalled();
+        expect(props.onLeave).not.toHaveBeenCalled();
       });
 
       it('calls the onPositionChange handler', () => {
-        expect(this.props.onPositionChange)
+        expect(props.onPositionChange)
           .toHaveBeenCalledWith({
             currentPosition: Waypoint.inside,
             previousPosition: Waypoint.above,
             event: jasmine.any(Event),
-            waypointTop: this.margin + this.topSpacerHeight - 200,
-            waypointBottom: this.margin + this.topSpacerHeight - 200,
-            viewportTop: this.margin,
-            viewportBottom: this.margin + this.parentHeight,
+            waypointTop: margin + topSpacerHeight - 200,
+            waypointBottom: margin + topSpacerHeight - 200,
+            viewportTop: margin,
+            viewportBottom: margin + parentHeight,
           });
       });
 
       it('calls the onLeave handler when scrolling up past the waypoint', () => {
-        scrollNodeTo(this.scrollable, 99);
+        scrollNodeTo(scrollable, 99);
 
-        expect(this.props.onLeave)
+        expect(props.onLeave)
           .toHaveBeenCalledWith({
             currentPosition: Waypoint.below,
             previousPosition: Waypoint.inside,
             event: jasmine.any(Event),
-            waypointTop: this.margin + this.topSpacerHeight - 99,
-            waypointBottom: this.margin + this.topSpacerHeight - 99,
-            viewportTop: this.margin,
-            viewportBottom: this.margin + this.parentHeight,
+            waypointTop: margin + topSpacerHeight - 99,
+            waypointBottom: margin + topSpacerHeight - 99,
+            viewportTop: margin,
+            viewportBottom: margin + parentHeight,
           });
       });
 
       it('does not call the onEnter handler again when scrolling up past the waypoint', () => {
-        scrollNodeTo(this.scrollable, 99);
+        scrollNodeTo(scrollable, 99);
 
-        expect(this.props.onEnter.calls.count()).toBe(1);
+        expect(props.onEnter.calls.count()).toBe(1);
       });
 
       it('calls the onPositionChange handler when scrolling up past the waypoint', () => {
-        scrollNodeTo(this.scrollable, 99);
+        scrollNodeTo(scrollable, 99);
 
-        expect(this.props.onPositionChange)
+        expect(props.onPositionChange)
           .toHaveBeenCalledWith({
             currentPosition: Waypoint.below,
             previousPosition: Waypoint.inside,
             event: jasmine.any(Event),
-            waypointTop: this.margin + this.topSpacerHeight - 99,
-            waypointBottom: this.margin + this.topSpacerHeight - 99,
-            viewportTop: this.margin,
-            viewportBottom: this.margin + this.parentHeight,
+            waypointTop: margin + topSpacerHeight - 99,
+            waypointBottom: margin + topSpacerHeight - 99,
+            viewportTop: margin,
+            viewportBottom: margin + parentHeight,
           });
       });
     });
@@ -1081,45 +1103,45 @@ describe('<Waypoint>', () => {
       // though, and one after. We want to treat this as if the waypoint was
       // visible for a brief moment, and so we fire both onEnter and onLeave.
       beforeEach(() => {
-        scrollNodeTo(this.scrollable, 0);
+        scrollNodeTo(scrollable, 0);
       });
 
       it('calls the onEnter handler', () => {
-        expect(this.props.onEnter)
+        expect(props.onEnter)
           .toHaveBeenCalledWith({
             currentPosition: Waypoint.inside,
             previousPosition: Waypoint.above,
             event: jasmine.any(Event),
-            waypointTop: this.margin + this.topSpacerHeight,
-            waypointBottom: this.margin + this.topSpacerHeight,
-            viewportTop: this.margin,
-            viewportBottom: this.margin + this.parentHeight,
+            waypointTop: margin + topSpacerHeight,
+            waypointBottom: margin + topSpacerHeight,
+            viewportTop: margin,
+            viewportBottom: margin + parentHeight,
           });
       });
 
       it('calls the onLeave handler', () => {
-        expect(this.props.onLeave)
+        expect(props.onLeave)
           .toHaveBeenCalledWith({
             currentPosition: Waypoint.below,
             previousPosition: Waypoint.inside,
             event: jasmine.any(Event),
-            waypointTop: this.margin + this.topSpacerHeight,
-            waypointBottom: this.margin + this.topSpacerHeight,
-            viewportTop: this.margin,
-            viewportBottom: this.margin + this.parentHeight,
+            waypointTop: margin + topSpacerHeight,
+            waypointBottom: margin + topSpacerHeight,
+            viewportTop: margin,
+            viewportBottom: margin + parentHeight,
           });
       });
 
       it('calls the onPositionChange handler', () => {
-        expect(this.props.onPositionChange)
+        expect(props.onPositionChange)
           .toHaveBeenCalledWith({
             currentPosition: Waypoint.below,
             previousPosition: Waypoint.above,
             event: jasmine.any(Event),
-            waypointTop: this.margin + this.topSpacerHeight,
-            waypointBottom: this.margin + this.topSpacerHeight,
-            viewportTop: this.margin,
-            viewportBottom: this.margin + this.parentHeight,
+            waypointTop: margin + topSpacerHeight,
+            waypointBottom: margin + topSpacerHeight,
+            viewportTop: margin,
+            viewportBottom: margin + parentHeight,
           });
       });
     });
@@ -1127,11 +1149,11 @@ describe('<Waypoint>', () => {
 
   describe('when the scrollable parent is not displayed', () => {
     it('calls the onLeave handler', () => {
-      this.component = this.subject();
-      const node = ReactDOM.findDOMNode(this.component);
+      const component = subject();
+      const node = ReactDOM.findDOMNode(component);
       node.style.display = 'none';
-      scrollNodeTo(this.component, 0);
-      expect(this.props.onLeave)
+      scrollNodeTo(component, 0);
+      expect(props.onLeave)
         .toHaveBeenCalledWith({
           currentPosition: Waypoint.invisible,
           previousPosition: Waypoint.inside,
@@ -1147,15 +1169,15 @@ describe('<Waypoint>', () => {
   describe('when the window is the scrollable parent', () => {
     beforeEach(() => {
       // Make the normal parent non-scrollable
-      this.parentStyle.height = 'auto';
-      this.parentStyle.overflow = 'visible';
+      parentStyle.height = 'auto';
+      parentStyle.overflow = 'visible';
 
       // This is only here to try and confuse the _findScrollableAncestor code.
       document.body.style.overflow = 'auto';
 
       // Make the spacers large enough to make the Waypoint render off-screen
-      this.topSpacerHeight = window.innerHeight + 1000;
-      this.bottomSpacerHeight = 1000;
+      topSpacerHeight = window.innerHeight + 1000;
+      bottomSpacerHeight = 1000;
     });
 
     afterEach(() => {
@@ -1164,51 +1186,51 @@ describe('<Waypoint>', () => {
     });
 
     it('does not fire the onEnter handler on mount', () => {
-      this.subject();
-      expect(this.props.onEnter).not.toHaveBeenCalled();
+      subject();
+      expect(props.onEnter).not.toHaveBeenCalled();
     });
 
     it('fires the onPositionChange handler on mount', () => {
-      this.subject();
-      expect(this.props.onPositionChange)
+      subject();
+      expect(props.onPositionChange)
         .toHaveBeenCalledWith({
           currentPosition: Waypoint.below,
           previousPosition: undefined,
           event: null,
-          waypointTop: this.margin + this.topSpacerHeight,
-          waypointBottom: this.margin + this.topSpacerHeight,
+          waypointTop: margin + topSpacerHeight,
+          waypointBottom: margin + topSpacerHeight,
           viewportTop: 0,
           viewportBottom: window.innerHeight,
         });
     });
 
     it('fires the onEnter handler when the Waypoint is in view', () => {
-      this.subject();
-      scrollNodeTo(window, this.topSpacerHeight - window.innerHeight / 2);
+      subject();
+      scrollNodeTo(window, topSpacerHeight - window.innerHeight / 2);
 
-      expect(this.props.onEnter)
+      expect(props.onEnter)
         .toHaveBeenCalledWith({
           currentPosition: Waypoint.inside,
           previousPosition: Waypoint.below,
           event: jasmine.any(Event),
-          waypointTop: this.margin + Math.ceil(window.innerHeight / 2),
-          waypointBottom: this.margin + Math.ceil(window.innerHeight / 2),
+          waypointTop: margin + Math.ceil(window.innerHeight / 2),
+          waypointBottom: margin + Math.ceil(window.innerHeight / 2),
           viewportTop: 0,
           viewportBottom: window.innerHeight,
         });
     });
 
     it('fires the onPositionChange handler when the Waypoint is in view', () => {
-      this.subject();
-      scrollNodeTo(window, this.topSpacerHeight - window.innerHeight / 2);
+      subject();
+      scrollNodeTo(window, topSpacerHeight - window.innerHeight / 2);
 
-      expect(this.props.onPositionChange)
+      expect(props.onPositionChange)
         .toHaveBeenCalledWith({
           currentPosition: Waypoint.inside,
           previousPosition: Waypoint.below,
           event: jasmine.any(Event),
-          waypointTop: this.margin + Math.ceil(window.innerHeight / 2),
-          waypointBottom: this.margin + Math.ceil(window.innerHeight / 2),
+          waypointTop: margin + Math.ceil(window.innerHeight / 2),
+          waypointBottom: margin + Math.ceil(window.innerHeight / 2),
           viewportTop: 0,
           viewportBottom: window.innerHeight,
         });
@@ -1220,10 +1242,10 @@ describe('<Waypoint>', () => {
     document.documentElement.style.overflow = 'auto';
 
     // Make the normal parent non-scrollable
-    this.parentStyle.height = 'auto';
-    this.parentStyle.overflow = 'visible';
+    parentStyle.height = 'auto';
+    parentStyle.overflow = 'visible';
 
-    expect(this.subject).not.toThrow();
+    expect(subject).not.toThrow();
 
     delete document.documentElement.style.overflow;
   });
@@ -1246,15 +1268,15 @@ describe('<Waypoint>', () => {
         }
       }
 
-      this.subject = () => renderAttached(<Wrapper {...this.props} />);
+      subject = () => renderAttached(<Wrapper {...props} />);
     });
 
     it('only calls onEnter once', (done) => {
-      this.subject();
+      subject();
 
       setTimeout(() => {
         scrollNodeTo(window, window.innerHeight);
-        expect(this.props.onEnter.calls.count()).toBe(1);
+        expect(props.onEnter.calls.count()).toBe(1);
         done();
       }, 0);
 
@@ -1267,15 +1289,15 @@ describe('<Waypoint>', () => {
       // document.body.style.marginTop = '0px';
       document.body.style.marginTop = '20px';
       document.body.style.position = 'relative';
-      // this.topSpacerHeight = 20;
+      // topSpacerHeight = 20;
 
       // Make the spacers large enough to make the Waypoint render off-screen
-      this.bottomSpacerHeight = window.innerHeight + 1000;
+      bottomSpacerHeight = window.innerHeight + 1000;
 
       // Make the normal parent non-scrollable
-      this.parentStyle = {};
+      parentStyle = {};
 
-      this.subject();
+      subject();
     });
 
     afterEach(() => {
@@ -1284,30 +1306,30 @@ describe('<Waypoint>', () => {
     });
 
     it('calls the onEnter handler', () => {
-      expect(this.props.onEnter)
+      expect(props.onEnter)
         .toHaveBeenCalledWith({
           currentPosition: Waypoint.inside,
           previousPosition: undefined,
           event: null,
-          waypointTop: 20 + this.topSpacerHeight,
-          waypointBottom: 20 + this.topSpacerHeight,
+          waypointTop: 20 + topSpacerHeight,
+          waypointBottom: 20 + topSpacerHeight,
           viewportTop: 0,
           viewportBottom: window.innerHeight,
         });
     });
 
     it('does not call the onLeave handler', () => {
-      expect(this.props.onLeave).not.toHaveBeenCalled();
+      expect(props.onLeave).not.toHaveBeenCalled();
     });
 
     it('calls the onPositionChange handler', () => {
-      expect(this.props.onPositionChange)
+      expect(props.onPositionChange)
         .toHaveBeenCalledWith({
           currentPosition: Waypoint.inside,
           previousPosition: undefined,
           event: null,
-          waypointTop: 20 + this.topSpacerHeight,
-          waypointBottom: 20 + this.topSpacerHeight,
+          waypointTop: 20 + topSpacerHeight,
+          waypointBottom: 20 + topSpacerHeight,
           viewportTop: 0,
           viewportBottom: window.innerHeight,
         });
@@ -1315,32 +1337,32 @@ describe('<Waypoint>', () => {
 
     describe('when scrolling while the waypoint is visible', () => {
       beforeEach(() => {
-        this.props.onPositionChange.calls.reset();
+        props.onPositionChange.calls.reset();
         scrollNodeTo(window, 10);
       });
 
       it('does not call the onEnter handler again', () => {
-        expect(this.props.onEnter.calls.count()).toBe(1);
+        expect(props.onEnter.calls.count()).toBe(1);
       });
 
       it('does not call the onLeave handler', () => {
-        expect(this.props.onLeave).not.toHaveBeenCalled();
+        expect(props.onLeave).not.toHaveBeenCalled();
       });
 
       it('does not call the onPositionChange handler', () => {
-        expect(this.props.onPositionChange).not.toHaveBeenCalled();
+        expect(props.onPositionChange).not.toHaveBeenCalled();
       });
 
       it('the onLeave handler is called when scrolling past the waypoint', () => {
         scrollNodeTo(window, 25);
 
-        expect(this.props.onLeave)
+        expect(props.onLeave)
           .toHaveBeenCalledWith({
             currentPosition: Waypoint.above,
             previousPosition: Waypoint.inside,
             event: jasmine.any(Event),
-            waypointTop: 20 + this.topSpacerHeight - 25,
-            waypointBottom: 20 + this.topSpacerHeight - 25,
+            waypointTop: 20 + topSpacerHeight - 25,
+            waypointBottom: 20 + topSpacerHeight - 25,
             viewportTop: 0,
             viewportBottom: window.innerHeight,
           });
@@ -1349,19 +1371,19 @@ describe('<Waypoint>', () => {
       it('does not call the onEnter handler when scrolling past the waypoint', () => {
         scrollNodeTo(window, 25);
 
-        expect(this.props.onEnter.calls.count()).toBe(1);
+        expect(props.onEnter.calls.count()).toBe(1);
       });
 
       it('the onPositionChange handler is called when scrolling past the waypoint', () => {
         scrollNodeTo(window, 25);
 
-        expect(this.props.onPositionChange)
+        expect(props.onPositionChange)
           .toHaveBeenCalledWith({
             currentPosition: Waypoint.above,
             previousPosition: Waypoint.inside,
             event: jasmine.any(Event),
-            waypointTop: 20 + this.topSpacerHeight - 25,
-            waypointBottom: 20 + this.topSpacerHeight - 25,
+            waypointTop: 20 + topSpacerHeight - 25,
+            waypointBottom: 20 + topSpacerHeight - 25,
             viewportTop: 0,
             viewportBottom: window.innerHeight,
           });
@@ -1384,36 +1406,44 @@ function scrollNodeToHorizontal(node, scrollLeft) {
 }
 
 describe('<Waypoint> Horizontal', () => {
+  let props;
+  let margin;
+  let parentWidth;
+  let parentStyle;
+  let leftSpacerWidth;
+  let rightSpacerWidth;
+  let subject;
+
   beforeEach(() => {
     jasmine.clock().install();
     document.body.style.margin = 'auto'; // should be no horizontal margin
 
-    this.props = {
+    props = {
       onEnter: jasmine.createSpy('onEnter'),
       onLeave: jasmine.createSpy('onLeave'),
       horizontal: true,
     };
 
-    this.margin = 10;
-    this.parentWidth = 100;
+    margin = 10;
+    parentWidth = 100;
 
-    this.parentStyle = {
+    parentStyle = {
       height: 100,
       overflow: 'auto',
       whiteSpace: 'nowrap',
-      width: this.parentWidth,
-      margin: this.margin, // Normalize the space left of the viewport.
+      width: parentWidth,
+      margin, // Normalize the space left of the viewport.
     };
 
-    this.leftSpacerWidth = 0;
-    this.rightSpacerWidth = 0;
+    leftSpacerWidth = 0;
+    rightSpacerWidth = 0;
 
-    this.subject = () => {
+    subject = () => {
       const el = renderAttached(
-        <div style={this.parentStyle}>
-          <div style={{ width: this.leftSpacerWidth, display: 'inline-block' }} />
-          <Waypoint {...this.props} />
-          <div style={{ width: this.rightSpacerWidth, display: 'inline-block' }} />
+        <div style={parentStyle}>
+          <div style={{ width: leftSpacerWidth, display: 'inline-block' }} />
+          <Waypoint {...props} />
+          <div style={{ width: rightSpacerWidth, display: 'inline-block' }} />
         </div>,
       );
 
@@ -1432,45 +1462,45 @@ describe('<Waypoint> Horizontal', () => {
 
   describe('when a div is the scrollable ancestor', () => {
     it('calls the onEnter handler when the Waypoint is visible on mount', () => {
-      this.subject();
+      subject();
 
-      expect(this.props.onEnter).toHaveBeenCalledWith({
+      expect(props.onEnter).toHaveBeenCalledWith({
         currentPosition: Waypoint.inside,
         previousPosition: undefined,
         event: null,
-        waypointTop: this.margin + this.leftSpacerWidth,
-        waypointBottom: this.margin + this.leftSpacerWidth,
-        viewportTop: this.margin,
-        viewportBottom: this.margin + this.parentWidth,
+        waypointTop: margin + leftSpacerWidth,
+        waypointBottom: margin + leftSpacerWidth,
+        viewportTop: margin,
+        viewportBottom: margin + parentWidth,
       });
     });
 
     it('does not call the onEnter handler when the Waypoint is not visible on mount', () => {
-      this.leftSpacerWidth = 300;
-      this.subject();
-      expect(this.props.onEnter).not.toHaveBeenCalled();
+      leftSpacerWidth = 300;
+      subject();
+      expect(props.onEnter).not.toHaveBeenCalled();
     });
   });
 
   describe('when the window is the scrollable ancestor', () => {
     beforeEach(() => {
-      delete this.parentStyle.overflow;
-      delete this.parentStyle.width;
+      delete parentStyle.overflow;
+      delete parentStyle.width;
     });
 
     it('calls the onEnter handler when the Waypoint is visible on mount', () => {
-      this.subject();
-      expect(this.props.onEnter).toHaveBeenCalled();
+      subject();
+      expect(props.onEnter).toHaveBeenCalled();
     });
 
     describe('when the Waypoint is not visible on mount', () => {
       beforeEach(() => {
-        this.leftSpacerWidth = window.innerWidth * 2;
-        this.subject();
+        leftSpacerWidth = window.innerWidth * 2;
+        subject();
       });
 
       it('does not call the onEnter handler', () => {
-        expect(this.props.onEnter).not.toHaveBeenCalled();
+        expect(props.onEnter).not.toHaveBeenCalled();
       });
 
       describe('when scrolled sideways to make the waypoint visible', () => {
@@ -1479,25 +1509,25 @@ describe('<Waypoint> Horizontal', () => {
         });
 
         it('calls the onEnter handler', () => {
-          expect(this.props.onEnter).toHaveBeenCalled();
+          expect(props.onEnter).toHaveBeenCalled();
         });
 
         it('does not call the onLeave handler', () => {
-          expect(this.props.onLeave).not.toHaveBeenCalled();
+          expect(props.onLeave).not.toHaveBeenCalled();
         });
 
         it('does not call the onEnter handler when scrolled back to initial position', () => {
-          this.props.onEnter.calls.reset();
+          props.onEnter.calls.reset();
           scrollNodeToHorizontal(window, 0);
 
-          expect(this.props.onEnter).not.toHaveBeenCalled();
+          expect(props.onEnter).not.toHaveBeenCalled();
         });
 
         it('calls the onLeave handler when scrolled back to initial position', () => {
-          this.props.onEnter.calls.reset();
+          props.onEnter.calls.reset();
           scrollNodeToHorizontal(window, 0);
 
-          expect(this.props.onLeave).toHaveBeenCalled();
+          expect(props.onLeave).toHaveBeenCalled();
         });
       });
     });

--- a/test/browser/waypoint_test.jsx
+++ b/test/browser/waypoint_test.jsx
@@ -1249,16 +1249,16 @@ describe('<Waypoint>', () => {
       this.subject = () => renderAttached(<Wrapper {...this.props} />);
     });
 
-    it('only calls onEnter once', () => {
+    it('only calls onEnter once', (done) => {
       this.subject();
 
-      return new Promise((resolve) => {
-        setTimeout(() => {
-          scrollNodeTo(window, window.innerHeight);
-          expect(this.props.onEnter.calls.count()).toBe(1);
-          resolve();
-        });
-      });
+      setTimeout(() => {
+        scrollNodeTo(window, window.innerHeight);
+        expect(this.props.onEnter.calls.count()).toBe(1);
+        done();
+      }, 0);
+
+      jasmine.clock().tick(5000);
     });
   });
 

--- a/webpack.config.performance-test.js
+++ b/webpack.config.performance-test.js
@@ -4,6 +4,7 @@ const path = require('path');
 // test/performance-test.html to profile the performance footprint of the
 // component.
 module.exports = {
+  mode: 'production',
   entry: path.join(__dirname, 'test/performance-test.jsx'),
   output: {
     path: path.join(__dirname, 'build'),


### PR DESCRIPTION
This one was interesting as quite a few things broke when upgrading stuff.

- Karma to version 6 worked as-is.
- `jasmine-core` to 2.99 was a relatively simple change. I believe the test has never worked, jasmine-core 2.7 just exposed that
- On that note, I couldn't figure out how to get up to `jasmine-core` 3
- Webpack 3 just worked but Webpack 4 required some changes as Webpack < 4 didn't correctly execute code in strict mode.

I think most of these changes are no brainers except perhaps the upgrade to webpack. I think it's valuable to test with older webpack versions to assure compatibility. However webpack 4 is now almost 3 years old. I think it's fine to ignore these older versions. Especially since it uncovered tests weren't actually executed in strict mode, potentially hiding bugs.