### PR TITLE
docs: update "bottomOffset" description

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,15 @@ enters or leaves the viewport. For details, see [Children](#children), below.
     ]),
 
     /**
-     * `bottomOffset` is like `topOffset`, but for the bottom of the container.
+     * `bottomOffset` can either be a number, in which case its a distance from the
+     * bottom of the container in pixels, or a string value. Valid string values are
+     * of the form "20px", which is parsed as pixels, or "20%", which is parsed
+     * as a percentage of the height of the containing element.
+     * For instance, if you pass "20%", and the containing element is 100px tall,
+     * then the waypoint will be triggered when it has been scrolled 20px beyond
+     * the bottom of the containing element.
+     * 
+     * Similar to `topOffset`, but for the bottom of the container.
      */
     bottomOffset: PropTypes.oneOfType([
       PropTypes.string,

--- a/index.d.ts
+++ b/index.d.ts
@@ -79,7 +79,15 @@ declare namespace Waypoint {
         topOffset?: string|number;
 
         /**
-         * `bottomOffset` is like `topOffset`, but for the bottom of the container.
+         * `bottomOffset` can either be a number, in which case its a distance from the
+         * bottom of the container in pixels, or a string value. Valid string values are
+         * of the form "20px", which is parsed as pixels, or "20%", which is parsed
+         * as a percentage of the height of the containing element.
+         * For instance, if you pass "20%", and the containing element is 100px tall,
+         * then the waypoint will be triggered when it has been scrolled 20px beyond
+         * the bottom of the containing element.
+         * 
+         * Similar to `topOffset`, but for the bottom of the container.
          */
         bottomOffset?: string|number;
 

--- a/src/waypoint.jsx
+++ b/src/waypoint.jsx
@@ -346,7 +346,14 @@ if (process.env.NODE_ENV !== 'production') {
       PropTypes.number,
     ]),
 
-    // `bottomOffset` is like `topOffset`, but for the bottom of the container.
+    // `bottomOffset` can either be a number, in which case its a distance from the
+    // bottom of the container in pixels, or a string value. Valid string values are
+    // of the form "20px", which is parsed as pixels, or "20%", which is parsed
+    // as a percentage of the height of the containing element.
+    // For instance, if you pass "20%", and the containing element is 100px tall,
+    // then the waypoint will be triggered when it has been scrolled 20px beyond
+    // the bottom of the containing element.
+    // Similar to `topOffset`, but for the bottom of the container.
     bottomOffset: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.number,


### PR DESCRIPTION
### Current state

![2021-03-11 4 50 53 PM](https://user-images.githubusercontent.com/11467765/110814736-066f7e80-828a-11eb-900f-a4bd9f6f3c03.jpg)

### Desired state

The similarity (or even "specularity") of "topOffset" and "bottomOffset" is kinda obvious, but still does make sense to describe both of them properly (similar to `onEnter` vs `onLeave`)