### PR TITLE
Use external @babel/runtime helpers

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,19 +3,35 @@
     "test": {
       "presets": [["airbnb", {
         "modules": true,
-        "transformRuntime": false
+        "runtimeHelpersUseESModules": false,
+        "runtimeVersion": "7.12.5",
+        "transformRuntime": true
       }]]
     },
-    "production": {
+
+    "cjs": {
       "presets": [["airbnb", {
         "modules": false,
-        "transformRuntime": false
+        "runtimeHelpersUseESModules": false,
+        "runtimeVersion": "7.12.5",
+        "transformRuntime": true
       }]]
     },
+
+    "es": {
+      "presets": [["airbnb", {
+        "modules": false,
+        "runtimeHelpersUseESModules": true,
+        "runtimeVersion": "7.12.5",
+        "transformRuntime": true
+      }]]
+    },
+
     "development": {
       "presets": [["airbnb", {
         "modules": false,
-        "transformRuntime": false
+        "runtimeVersion": "7.12.5",
+        "transformRuntime": true
       }]]
     }
   }

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "scrollspy"
   ],
   "dependencies": {
+    "@babel/runtime": "^7.12.5",
     "consolidated-events": "^1.1.0 || ^2.0.0",
     "prop-types": "^15.0.0",
     "react-is": "^17.0.1"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,22 +1,40 @@
 import babel from '@rollup/plugin-babel';
 import pkg from './package.json';
 
-export default [
-  {
+const depsSet = new Set([
+  ...Object.keys(pkg.dependencies),
+  ...Object.keys(pkg.devDependencies),
+]);
+
+/**
+ * @param {'es' | 'cjs'} format
+ */
+function makeBuild(format) {
+  return {
     input: 'src/waypoint.jsx',
-    external: [
-      ...Object.keys(pkg.dependencies),
-      ...Object.keys(pkg.peerDependencies),
-    ],
-    output: [
-      { file: pkg.main, format: 'cjs' },
-      { file: pkg.module, format: 'es' },
-    ],
+
+    external: (id) => {
+      if (id.startsWith('.') || id.startsWith('/')) {
+        return false;
+      }
+
+      const packageName = id.startsWith('@')
+        ? id.split('/').slice(0, 2).join('/')
+        : id.split('/')[0];
+
+      return depsSet.has(packageName);
+    },
+
+    output: [{ file: format === 'es' ? pkg.module : pkg.main, format }],
+
     plugins: [
       babel({
-        babelHelpers: 'bundled',
+        babelHelpers: 'runtime',
+        envName: format,
         exclude: ['node_modules/**'],
       }),
     ],
-  },
-];
+  };
+}
+
+export default [makeBuild('es'), makeBuild('cjs')];


### PR DESCRIPTION
Fixes #302

This is similar to #341, except it avoids having to run babel on the
rollup output, which allows us to leave the babel configuration in
the .babelrc file.

cjs/index.js diff:

```diff
4a5,8
> var _classCallCheck = require('@babel/runtime/helpers/classCallCheck');
> var _createClass = require('@babel/runtime/helpers/createClass');
> var _inherits = require('@babel/runtime/helpers/inherits');
> var _createSuper = require('@babel/runtime/helpers/createSuper');
11a16,19
> var _classCallCheck__default = /*#__PURE__*/_interopDefaultLegacy(_classCallCheck);
> var _createClass__default = /*#__PURE__*/_interopDefaultLegacy(_createClass);
> var _inherits__default = /*#__PURE__*/_interopDefaultLegacy(_inherits);
> var _createSuper__default = /*#__PURE__*/_interopDefaultLegacy(_createSuper);
15,115d22
< function _classCallCheck(instance, Constructor) {
<   if (!(instance instanceof Constructor)) {
<     throw new TypeError("Cannot call a class as a function");
<   }
< }
< 
< function _defineProperties(target, props) {
<   for (var i = 0; i < props.length; i++) {
<     var descriptor = props[i];
<     descriptor.enumerable = descriptor.enumerable || false;
<     descriptor.configurable = true;
<     if ("value" in descriptor) descriptor.writable = true;
<     Object.defineProperty(target, descriptor.key, descriptor);
<   }
< }
< 
< function _createClass(Constructor, protoProps, staticProps) {
<   if (protoProps) _defineProperties(Constructor.prototype, protoProps);
<   if (staticProps) _defineProperties(Constructor, staticProps);
<   return Constructor;
< }
< 
< function _inherits(subClass, superClass) {
<   if (typeof superClass !== "function" && superClass !== null) {
<     throw new TypeError("Super expression must either be null or a function");
<   }
< 
<   subClass.prototype = Object.create(superClass && superClass.prototype, {
<     constructor: {
<       value: subClass,
<       writable: true,
<       configurable: true
<     }
<   });
<   if (superClass) _setPrototypeOf(subClass, superClass);
< }
< 
< function _getPrototypeOf(o) {
<   _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) {
<     return o.__proto__ || Object.getPrototypeOf(o);
<   };
<   return _getPrototypeOf(o);
< }
< 
< function _setPrototypeOf(o, p) {
<   _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) {
<     o.__proto__ = p;
<     return o;
<   };
< 
<   return _setPrototypeOf(o, p);
< }
< 
< function _isNativeReflectConstruct() {
<   if (typeof Reflect === "undefined" || !Reflect.construct) return false;
<   if (Reflect.construct.sham) return false;
<   if (typeof Proxy === "function") return true;
< 
<   try {
<     Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {}));
<     return true;
<   } catch (e) {
<     return false;
<   }
< }
< 
< function _assertThisInitialized(self) {
<   if (self === void 0) {
<     throw new ReferenceError("this hasn't been initialised - super() hasn't been called");
<   }
< 
<   return self;
< }
< 
< function _possibleConstructorReturn(self, call) {
<   if (call && (typeof call === "object" || typeof call === "function")) {
<     return call;
<   }
< 
<   return _assertThisInitialized(self);
< }
< 
< function _createSuper(Derived) {
<   var hasNativeReflectConstruct = _isNativeReflectConstruct();
< 
<   return function _createSuperInternal() {
<     var Super = _getPrototypeOf(Derived),
<         result;
< 
<     if (hasNativeReflectConstruct) {
<       var NewTarget = _getPrototypeOf(this).constructor;
< 
<       result = Reflect.construct(Super, arguments, NewTarget);
<     } else {
<       result = Super.apply(this, arguments);
<     }
< 
<     return _possibleConstructorReturn(this, result);
<   };
< }
< 
327c234
<   _inherits(Waypoint, _React$PureComponent);
---
>   _inherits__default['default'](Waypoint, _React$PureComponent);
329c236
<   var _super = _createSuper(Waypoint);
---
>   var _super = _createSuper__default['default'](Waypoint);
334c241
<     _classCallCheck(this, Waypoint);
---
>     _classCallCheck__default['default'](this, Waypoint);
345c252
<   _createClass(Waypoint, [{
---
>   _createClass__default['default'](Waypoint, [{
```

es/index.js diff
```diff
0a1,4
> import _classCallCheck from '@babel/runtime/helpers/esm/classCallCheck';
> import _createClass from '@babel/runtime/helpers/esm/createClass';
> import _inherits from '@babel/runtime/helpers/esm/inherits';
> import _createSuper from '@babel/runtime/helpers/esm/createSuper';
6,106d9
< function _classCallCheck(instance, Constructor) {
<   if (!(instance instanceof Constructor)) {
<     throw new TypeError("Cannot call a class as a function");
<   }
< }
< 
< function _defineProperties(target, props) {
<   for (var i = 0; i < props.length; i++) {
<     var descriptor = props[i];
<     descriptor.enumerable = descriptor.enumerable || false;
<     descriptor.configurable = true;
<     if ("value" in descriptor) descriptor.writable = true;
<     Object.defineProperty(target, descriptor.key, descriptor);
<   }
< }
< 
< function _createClass(Constructor, protoProps, staticProps) {
<   if (protoProps) _defineProperties(Constructor.prototype, protoProps);
<   if (staticProps) _defineProperties(Constructor, staticProps);
<   return Constructor;
< }
< 
< function _inherits(subClass, superClass) {
<   if (typeof superClass !== "function" && superClass !== null) {
<     throw new TypeError("Super expression must either be null or a function");
<   }
< 
<   subClass.prototype = Object.create(superClass && superClass.prototype, {
<     constructor: {
<       value: subClass,
<       writable: true,
<       configurable: true
<     }
<   });
<   if (superClass) _setPrototypeOf(subClass, superClass);
< }
< 
< function _getPrototypeOf(o) {
<   _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) {
<     return o.__proto__ || Object.getPrototypeOf(o);
<   };
<   return _getPrototypeOf(o);
< }
< 
< function _setPrototypeOf(o, p) {
<   _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) {
<     o.__proto__ = p;
<     return o;
<   };
< 
<   return _setPrototypeOf(o, p);
< }
< 
< function _isNativeReflectConstruct() {
<   if (typeof Reflect === "undefined" || !Reflect.construct) return false;
<   if (Reflect.construct.sham) return false;
<   if (typeof Proxy === "function") return true;
< 
<   try {
<     Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {}));
<     return true;
<   } catch (e) {
<     return false;
<   }
< }
< 
< function _assertThisInitialized(self) {
<   if (self === void 0) {
<     throw new ReferenceError("this hasn't been initialised - super() hasn't been called");
<   }
< 
<   return self;
< }
< 
< function _possibleConstructorReturn(self, call) {
<   if (call && (typeof call === "object" || typeof call === "function")) {
<     return call;
<   }
< 
<   return _assertThisInitialized(self);
< }
< 
< function _createSuper(Derived) {
<   var hasNativeReflectConstruct = _isNativeReflectConstruct();
< 
<   return function _createSuperInternal() {
<     var Super = _getPrototypeOf(Derived),
<         result;
< 
<     if (hasNativeReflectConstruct) {
<       var NewTarget = _getPrototypeOf(this).constructor;
< 
<       result = Reflect.construct(Super, arguments, NewTarget);
<     } else {
<       result = Super.apply(this, arguments);
<     }
< 
<     return _possibleConstructorReturn(this, result);
<   };
< }
< 
```