### PR TITLE
REACT18 TS - add support for children props

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -110,5 +110,10 @@ declare namespace Waypoint {
          * things down significantly, so it should only be used during development.
          */
         debug?: boolean;
+      
+        /**
+         * Since React 18 Children are no longer implied, therefore we specify them here
+         */
+        children?: React.ReactNode;
     }
 }


### PR DESCRIPTION
REACT18 TS - Children are no longer  implicit property of a Component.
Children has to now be specified explicitly on the props declaration.